### PR TITLE
Add fixes for environment and container images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ POSTGRES_PASSWORD=your_secure_password_here
 # API Configuration
 API_PORT=8000
 UI_PORT=3000
+API_URL=http://api:8000  # UI nginx proxy target (use http://localhost:8000 if API runs outside Docker)
+NGINX_LISTEN=80  # Nginx listen address:port (e.g., 80, 0.0.0.0:80, 127.0.0.1:8080)
 
 # API Keys (Required for production)
 GROQ_API_KEY=your_groq_api_key_here

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -11,6 +11,8 @@ services:
       - "${UI_PORT:-3000}:80"
     environment:
       - NODE_ENV=production
+      - API_URL=${API_URL:-http://api:8000}
+      - NGINX_LISTEN=${NGINX_LISTEN:-80}
     restart: unless-stopped
 
   api:
@@ -70,6 +72,7 @@ services:
       - BATCH_SIZE=${BATCH_SIZE:-5}
       - ASR_PROVIDER=${ASR_PROVIDER:-groq}
       - ASR_MODEL=${ASR_MODEL:-whisper-large-v3-turbo}
+      - WHISPER_ASR_URL=${WHISPER_ASR_URL:-http://localhost:9000}
       - LLM_PROVIDER=${LLM_PROVIDER:-groq}
       - LLM_MODEL=${LLM_MODEL:-llama-3.3-70b-versatile}
       - GROQ_API_KEY=${GROQ_API_KEY}

--- a/compose.yml
+++ b/compose.yml
@@ -6,6 +6,9 @@ services:
     image: ${REGISTRY:-}voicevault-ui:${VERSION:-latest}
     ports:
       - "${UI_PORT:-3000}:80"
+    environment:
+      - API_URL=${API_URL:-http://api:8000}
+      - NGINX_LISTEN=${NGINX_LISTEN:-80}
     depends_on:
       - api
     restart: unless-stopped
@@ -83,6 +86,7 @@ services:
       - BATCH_SIZE=${BATCH_SIZE:-5}
       - ASR_PROVIDER=${ASR_PROVIDER:-groq}
       - ASR_MODEL=${ASR_MODEL:-whisper-large-v3-turbo}
+      - WHISPER_ASR_URL=${WHISPER_ASR_URL:-http://localhost:9000}
       - LLM_PROVIDER=${LLM_PROVIDER:-groq}
       - LLM_MODEL=${LLM_MODEL:-llama-3.3-70b-versatile}
       - GROQ_API_KEY=${GROQ_API_KEY}

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -18,8 +18,12 @@ RUN npm run build
 # Production stage
 FROM nginx:alpine
 
-# Copy custom nginx config
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+# Copy nginx config template (will be processed at runtime)
+COPY nginx.conf.template /etc/nginx/conf.d/default.conf.template
+
+# Copy entrypoint script
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 
 # Copy built app
 COPY --from=build /app/dist /usr/share/nginx/html
@@ -27,4 +31,10 @@ COPY --from=build /app/dist /usr/share/nginx/html
 # Expose port
 EXPOSE 80
 
+# Environment variables with defaults
+ENV API_URL=http://api:8000
+ENV NGINX_RESOLVER=127.0.0.11
+ENV NGINX_LISTEN=80
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/ui/docker-entrypoint.sh
+++ b/ui/docker-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+# Default values
+API_URL=${API_URL:-http://api:8000}
+NGINX_RESOLVER=${NGINX_RESOLVER:-127.0.0.11}
+NGINX_LISTEN=${NGINX_LISTEN:-80}
+
+export API_URL
+export NGINX_RESOLVER
+export NGINX_LISTEN
+
+# Substitute environment variables in nginx config template
+# Only substitute specific variables, leaving nginx variables ($uri, $host, etc.) intact
+envsubst '${API_URL} ${NGINX_RESOLVER} ${NGINX_LISTEN}' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+
+echo "Nginx configured with:"
+echo "  NGINX_LISTEN: ${NGINX_LISTEN}"
+echo "  API_URL: ${API_URL}"
+echo "  NGINX_RESOLVER: ${NGINX_RESOLVER}"
+
+# Execute the main command (nginx)
+exec "$@"

--- a/ui/nginx.conf.template
+++ b/ui/nginx.conf.template
@@ -1,0 +1,46 @@
+server {
+    listen ${NGINX_LISTEN};
+    server_name localhost;
+
+    # Docker internal DNS resolver (with fallback for non-Docker environments)
+    resolver ${NGINX_RESOLVER} valid=30s ipv6=off;
+
+    # Allow large file uploads (match backend max_file_size: 500MB)
+    client_max_body_size 500M;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Handle client-side routing
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # API proxy - handle both with and without trailing slash
+    location ~ ^/api(.*)$ {
+        set $api_backend ${API_URL};
+        proxy_pass $api_backend/api$1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect off;
+
+        # Extended timeouts for large file uploads
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
+    }
+
+    # Gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json;
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}


### PR DESCRIPTION
This pull request introduces environment-based configuration for the UI's Nginx proxy and API connectivity, improving deployment flexibility for both Docker and non-Docker environments. It adds a template-driven Nginx configuration, a runtime entrypoint script for environment variable substitution, and updates Docker Compose and environment files to support these changes. Additionally, it introduces a configurable ASR service URL for the API.

**UI Nginx configuration and environment variable support:**

* Added `nginx.conf.template` and a new entrypoint script (`docker-entrypoint.sh`) to the UI Docker image, enabling runtime substitution of environment variables like `API_URL` and `NGINX_LISTEN` in the Nginx config. This allows the UI to dynamically route API requests based on deployment context. (`ui/nginx.conf.template`, `ui/docker-entrypoint.sh`, `ui/Dockerfile`) [[1]](diffhunk://#diff-d5f665a3cbda7d36cb9ef029d1c85cc1bf4d38238f0cc354d76997ad7f99f63fR1-R46) [[2]](diffhunk://#diff-d69ece518836dd46b657ddf78df03c2eb3da06c934dbb0a308b94006cdeb6283R1-R23) [[3]](diffhunk://#diff-9d3a4ec1828c999fc8943d1090a2689e006f5638f4ca050e7dea6c610e10b6e1L21-R39)
* Updated the UI service definitions in both `compose.yml` and `compose.prod.yml` to pass `API_URL` and `NGINX_LISTEN` as environment variables, defaulting to Docker-internal addresses but allowing overrides. (`compose.yml`, `compose.prod.yml`) [[1]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588R9-R11) [[2]](diffhunk://#diff-3c22f73b491d3a17d8206e1d06eb996298a8640f24a5b5db28f8d961f9c6771bR14-R15)

**Environment variable documentation and configuration:**

* Added `API_URL` and `NGINX_LISTEN` to `.env.example` to document their usage and provide sensible defaults for local and Docker deployments. (`.env.example`)

**API service configuration:**

* Introduced a configurable `WHISPER_ASR_URL` environment variable for the API service in both Docker Compose files, allowing the ASR backend to be easily pointed to a different host or port. (`compose.yml`, `compose.prod.yml`) [[1]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588R89) [[2]](diffhunk://#diff-3c22f73b491d3a17d8206e1d06eb996298a8640f24a5b5db28f8d961f9c6771bR75)