### PR TITLE
Add pagination details to api, fixes pagination in ui

### DIFF
--- a/api/app/api/routes/entries.py
+++ b/api/app/api/routes/entries.py
@@ -127,11 +127,16 @@ async def get_entries(
     entry_service = EntryService(db)
     entries, total = entry_service.get_entries(page=page, per_page=per_page, search=search)
 
+    total_pages = (total + per_page - 1) // per_page if total > 0 else 0
+
     return EntryList(
         entries=[EntryResponse.from_orm(entry) for entry in entries],
         total=total,
         page=page,
-        per_page=per_page
+        per_page=per_page,
+        total_pages=total_pages,
+        has_next=page < total_pages,
+        has_previous=page > 1
     )
 
 @router.get("/{entry_id}", response_model=EntryResponse)

--- a/api/app/models/schemas.py
+++ b/api/app/models/schemas.py
@@ -37,6 +37,9 @@ class EntryList(BaseModel):
     total: int
     page: int
     per_page: int
+    total_pages: int
+    has_next: bool
+    has_previous: bool
 
 class ChatMessage(BaseModel):
     role: str  # "user" or "assistant"

--- a/api/app/services/entry_service.py
+++ b/api/app/services/entry_service.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple, List
 from uuid import UUID
 import os
 from pathlib import Path
+from loguru import logger
 
 from app.models.entry import Entry, EntryStatus, SourceType
 from app.core.config import settings
@@ -57,7 +58,19 @@ class EntryService:
 
         total = query.count()
 
-        entries = query.order_by(Entry.created_at.desc()).offset((page - 1) * per_page).limit(per_page).all()
+        # Calculate offset explicitly
+        offset = (page - 1) * per_page
+        logger.debug(f"Pagination: page={page}, per_page={per_page}, offset={offset}, total={total}")
+
+        entries = (
+            query
+            .order_by(Entry.created_at.desc(), Entry.id.desc())
+            .offset(offset)
+            .limit(per_page)
+            .all()
+        )
+
+        logger.debug(f"Returned {len(entries)} entries, IDs: {[str(e.id)[:8] for e in entries]}")
 
         return entries, total
     

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -22,7 +22,7 @@ server {
 
     # API proxy - handle both with and without trailing slash
     location ~ ^/api(.*)$ {
-        proxy_pass http://api_backend/api$1;
+        proxy_pass http://api_backend/api$1$is_args$args;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/ui/nginx.conf.template
+++ b/ui/nginx.conf.template
@@ -19,7 +19,7 @@ server {
     # API proxy - handle both with and without trailing slash
     location ~ ^/api(.*)$ {
         set $api_backend ${API_URL};
-        proxy_pass $api_backend/api$1;
+        proxy_pass $api_backend/api$1$is_args$args;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This pull request introduces improvements to the pagination API for entries, adds enhanced logging for debugging pagination in the entry service, and updates the Nginx configuration to better handle query strings when proxying API requests.

**Pagination and API Response Enhancements:**

* Added `total_pages`, `has_next`, and `has_previous` fields to the `EntryList` response model in `schemas.py` and updated the `get_entries` endpoint to compute and return these values, improving the API's pagination metadata. [[1]](diffhunk://#diff-b6bb0751bca121704b69b21d07a5c104a5a5d291c1705dadb6d1344c9b9547f5R40-R42) [[2]](diffhunk://#diff-7959d00929a7db7aa9d38dfef4ea5e1aa413809afae83bed382a4000dc10be6aR130-R139)

**Service Layer Logging and Pagination Logic:**

* Introduced detailed debug logging in `entry_service.py` to log pagination parameters and returned entry IDs, and clarified offset calculation for paginated queries. Also updated the sorting to include both `created_at` and `id` for deterministic ordering. [[1]](diffhunk://#diff-5e431132045a7c51e6250e6a50318e553917a4f6349eaf05be264898b481f548L60-R73) [[2]](diffhunk://#diff-5e431132045a7c51e6250e6a50318e553917a4f6349eaf05be264898b481f548R7)

**Nginx Proxy Configuration Improvements:**

* Modified both `nginx.conf` and `nginx.conf.template` to append query strings to proxied API requests using `$is_args$args`, ensuring that query parameters are correctly forwarded to the backend API. [[1]](diffhunk://#diff-8163afc9f16528f6693e5aec0c5c7edfdd20021f854b0ada49e5db5a3dd80dbeL25-R25) [[2]](diffhunk://#diff-d5f665a3cbda7d36cb9ef029d1c85cc1bf4d38238f0cc354d76997ad7f99f63fL22-R22)