### PR TITLE
Add prompt prompt template management and chat integration

### DIFF
--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -11,6 +11,7 @@ from app.db.database import Base
 from app.core.config import settings
 # Import all models to ensure they're registered
 from app.models.entry import Entry
+from app.models.prompt_template import PromptTemplate
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/api/app/api/routes/prompt_templates.py
+++ b/api/app/api/routes/prompt_templates.py
@@ -1,0 +1,69 @@
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.core.auth import get_current_user
+from app.db.database import get_db
+from app.models.schemas import (
+    PromptTemplateCreate,
+    PromptTemplateResponse,
+    PromptTemplateUpdate,
+)
+from app.services.prompt_template_service import PromptTemplateService
+
+router = APIRouter()
+
+
+@router.get("/", response_model=List[PromptTemplateResponse])
+async def list_prompt_templates(
+    active_only: bool = False,
+    db: Session = Depends(get_db),
+    current_user: bool = Depends(get_current_user),
+):
+    service = PromptTemplateService(db)
+    return service.list_templates(active_only=active_only)
+
+
+@router.post("/", response_model=PromptTemplateResponse)
+async def create_prompt_template(
+    template_data: PromptTemplateCreate,
+    db: Session = Depends(get_db),
+    current_user: bool = Depends(get_current_user),
+):
+    service = PromptTemplateService(db)
+    template = service.create_template(**template_data.dict())
+    return template
+
+
+@router.put("/{template_id}", response_model=PromptTemplateResponse)
+async def update_prompt_template(
+    template_id: UUID,
+    template_data: PromptTemplateUpdate,
+    db: Session = Depends(get_db),
+    current_user: bool = Depends(get_current_user),
+):
+    service = PromptTemplateService(db)
+    update_data = template_data.dict(exclude_unset=True)
+    template = service.update_template(template_id, **update_data)
+
+    if not template:
+        raise HTTPException(status_code=404, detail="Prompt template not found")
+
+    return template
+
+
+@router.delete("/{template_id}")
+async def delete_prompt_template(
+    template_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: bool = Depends(get_current_user),
+):
+    service = PromptTemplateService(db)
+    deleted = service.delete_template(template_id)
+
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Prompt template not found")
+
+    return {"message": "Prompt template deleted successfully"}

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -2,9 +2,10 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
-from app.api.routes import entries, auth
-from app.db.database import engine
-from app.models import entry  # Import models to register them
+from app.api.routes import entries, auth, prompt_templates
+from app.db.database import engine, SessionLocal
+from app.models import entry, prompt_template  # Import models to register them
+from app.services.prompt_template_service import PromptTemplateService
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -14,6 +15,11 @@ async def lifespan(app: FastAPI):
         from app.db.database import Base, ensure_entry_schema
         Base.metadata.create_all(bind=engine)
         ensure_entry_schema()
+        db = SessionLocal()
+        try:
+            PromptTemplateService(db).seed_defaults_if_empty()
+        finally:
+            db.close()
         print("✅ Database tables created/verified")
     except Exception as e:
         print(f"❌ Database migration failed: {str(e)}")
@@ -44,6 +50,7 @@ app.add_middleware(
 # Include routers
 app.include_router(auth.router, prefix="/api/auth", tags=["authentication"])
 app.include_router(entries.router, prefix="/api/entries", tags=["entries"])
+app.include_router(prompt_templates.router, prefix="/api/prompt-templates", tags=["prompt-templates"])
 
 @app.get("/")
 async def root():

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -1,3 +1,4 @@
 from .entry import Entry, EntryStatus, SourceType
+from .prompt_template import PromptTemplate
 
-__all__ = ["Entry", "EntryStatus", "SourceType"]
+__all__ = ["Entry", "EntryStatus", "SourceType", "PromptTemplate"]

--- a/api/app/models/prompt_template.py
+++ b/api/app/models/prompt_template.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from datetime import datetime
+import uuid
+
+from app.db.database import Base
+
+
+class PromptTemplate(Base):
+    __tablename__ = "prompt_templates"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    label = Column(String(255), nullable=False)
+    preview_text = Column(String(512), nullable=True)
+    body_markdown = Column(Text, nullable=False)
+    sort_order = Column(Integer, nullable=False, default=0)
+    is_active = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/api/app/models/schemas.py
+++ b/api/app/models/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, HttpUrl
+from pydantic import BaseModel, Field, HttpUrl
 from typing import Optional
 from datetime import datetime
 from uuid import UUID
@@ -61,3 +61,33 @@ class ChatResponse(BaseModel):
 class SummaryResponse(BaseModel):
     summary: str
     timestamp: datetime
+
+
+class PromptTemplateCreate(BaseModel):
+    label: str = Field(..., min_length=1, max_length=255)
+    preview_text: Optional[str] = Field(default=None, max_length=512)
+    body_markdown: str = Field(..., min_length=1)
+    sort_order: int = 0
+    is_active: bool = True
+
+
+class PromptTemplateUpdate(BaseModel):
+    label: Optional[str] = Field(default=None, min_length=1, max_length=255)
+    preview_text: Optional[str] = Field(default=None, max_length=512)
+    body_markdown: Optional[str] = Field(default=None, min_length=1)
+    sort_order: Optional[int] = None
+    is_active: Optional[bool] = None
+
+
+class PromptTemplateResponse(BaseModel):
+    id: UUID
+    label: str
+    preview_text: Optional[str] = None
+    body_markdown: str
+    sort_order: int
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/api/app/services/prompt_template_service.py
+++ b/api/app/services/prompt_template_service.py
@@ -1,0 +1,124 @@
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.models.prompt_template import PromptTemplate
+
+
+DEFAULT_PROMPT_TEMPLATES = [
+    {
+        "label": "Action items",
+        "preview_text": "Extract decisions, owners, and deadlines.",
+        "body_markdown": "## Action Items\n- List the action items\n- Include owners when available\n- Include due dates when available",
+        "sort_order": 10,
+        "is_active": True,
+    },
+    {
+        "label": "Key decisions",
+        "preview_text": "Summarize the major decisions that were made.",
+        "body_markdown": "## Key Decisions\n- Summarize the major decisions\n- Note any context behind each decision",
+        "sort_order": 20,
+        "is_active": True,
+    },
+    {
+        "label": "Risks and blockers",
+        "preview_text": "Highlight open risks, blockers, and follow-up items.",
+        "body_markdown": "## Risks and Blockers\n- Identify open risks\n- Identify blockers\n- Note the follow-up needed for each item",
+        "sort_order": 30,
+        "is_active": True,
+    },
+]
+
+
+class PromptTemplateService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def list_templates(self, active_only: bool = False) -> list[PromptTemplate]:
+        query = self.db.query(PromptTemplate)
+        if active_only:
+            query = query.filter(PromptTemplate.is_active.is_(True))
+
+        return (
+            query.order_by(
+                PromptTemplate.sort_order.asc(),
+                PromptTemplate.created_at.asc(),
+            ).all()
+        )
+
+    def get_template(self, template_id: UUID) -> Optional[PromptTemplate]:
+        return (
+            self.db.query(PromptTemplate)
+            .filter(PromptTemplate.id == template_id)
+            .first()
+        )
+
+    def create_template(
+        self,
+        *,
+        label: str,
+        preview_text: Optional[str],
+        body_markdown: str,
+        sort_order: int = 0,
+        is_active: bool = True,
+    ) -> PromptTemplate:
+        template = PromptTemplate(
+            label=label,
+            preview_text=preview_text,
+            body_markdown=body_markdown,
+            sort_order=sort_order,
+            is_active=is_active,
+        )
+
+        self.db.add(template)
+        self.db.commit()
+        self.db.refresh(template)
+        return template
+
+    def update_template(
+        self,
+        template_id: UUID,
+        *,
+        label: Optional[str] = None,
+        preview_text: Optional[str] = None,
+        body_markdown: Optional[str] = None,
+        sort_order: Optional[int] = None,
+        is_active: Optional[bool] = None,
+    ) -> Optional[PromptTemplate]:
+        template = self.get_template(template_id)
+        if not template:
+            return None
+
+        if label is not None:
+            template.label = label
+        if preview_text is not None:
+            template.preview_text = preview_text
+        if body_markdown is not None:
+            template.body_markdown = body_markdown
+        if sort_order is not None:
+            template.sort_order = sort_order
+        if is_active is not None:
+            template.is_active = is_active
+
+        self.db.commit()
+        self.db.refresh(template)
+        return template
+
+    def delete_template(self, template_id: UUID) -> bool:
+        template = self.get_template(template_id)
+        if not template:
+            return False
+
+        self.db.delete(template)
+        self.db.commit()
+        return True
+
+    def seed_defaults_if_empty(self) -> int:
+        if self.db.query(PromptTemplate).count() > 0:
+            return 0
+
+        templates = [PromptTemplate(**template_data) for template_data in DEFAULT_PROMPT_TEMPLATES]
+        self.db.add_all(templates)
+        self.db.commit()
+        return len(templates)

--- a/api/tests/test_prompt_template_service.py
+++ b/api/tests/test_prompt_template_service.py
@@ -1,0 +1,69 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.services.prompt_template_service import DEFAULT_PROMPT_TEMPLATES, PromptTemplateService
+
+
+class PromptTemplateServiceTests(TestCase):
+    def make_template(self, **overrides):
+        base = {
+            "id": "template-1",
+            "label": "Action items",
+            "preview_text": "Extract action items",
+            "body_markdown": "## Action Items\n- item",
+            "sort_order": 10,
+            "is_active": True,
+        }
+        base.update(overrides)
+        return SimpleNamespace(**base)
+
+    def test_lists_templates_by_sort_order(self):
+        db = MagicMock()
+        service = PromptTemplateService(db)
+        query = db.query.return_value
+        ordered = query.order_by.return_value
+        ordered.all.return_value = [
+            self.make_template(sort_order=10),
+            self.make_template(id="template-2", sort_order=20),
+        ]
+
+        templates = service.list_templates()
+
+        self.assertEqual([template.sort_order for template in templates], [10, 20])
+
+    def test_creates_template(self):
+        db = MagicMock()
+        service = PromptTemplateService(db)
+        template = service.create_template(
+            label="Action items",
+            preview_text="Extract action items",
+            body_markdown="## Action Items\n- item",
+            sort_order=10,
+            is_active=True,
+        )
+
+        self.assertEqual(template.label, "Action items")
+        self.assertEqual(template.sort_order, 10)
+        db.add.assert_called_once()
+        db.commit.assert_called_once()
+        db.refresh.assert_called_once_with(template)
+
+    def test_seeds_defaults_only_when_empty(self):
+        db = MagicMock()
+        service = PromptTemplateService(db)
+        query = db.query.return_value
+        query.count.side_effect = [0, 2]
+
+        with patch.object(service.db, "add_all") as add_all_mock:
+            first = service.seed_defaults_if_empty()
+            second = service.seed_defaults_if_empty()
+
+        self.assertEqual(first, len(DEFAULT_PROMPT_TEMPLATES))
+        self.assertEqual(second, 0)
+        add_all_mock.assert_called_once()
+        db.commit.assert_called_once()

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Mic, Brain, Zap, LogOut, Plus } from 'lucide-react';
+import { Mic, Brain, Zap, LogOut, Plus, Settings } from 'lucide-react';
+
 import { EntryForm } from './components/EntryForm';
 import { EntryList } from './components/EntryList';
 import { ChatInterface } from './components/ChatInterface';
 import { Login } from './components/Login';
+import { PromptTemplateManager } from './components/PromptTemplateManager';
 import { SearchBar } from './components/SearchBar';
 import { entryApi, auth } from './services/api';
-import { Entry } from './types';
+import { Entry, PromptTemplate, PromptTemplateCreate, PromptTemplateUpdate } from './types';
 import 'highlight.js/styles/github.css';
 
 type EntryFilter = 'active' | 'archived';
@@ -14,6 +16,9 @@ type EntryFilter = 'active' | 'archived';
 function App() {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [entries, setEntries] = useState<Entry[]>([]);
+  const [promptTemplates, setPromptTemplates] = useState<PromptTemplate[]>([]);
+  const [promptTemplatesLoading, setPromptTemplatesLoading] = useState(false);
+  const [promptTemplatesError, setPromptTemplatesError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [selectedEntry, setSelectedEntry] = useState<Entry | null>(null);
   const [page, setPage] = useState(1);
@@ -22,8 +27,13 @@ function App() {
   const [searchQuery, setSearchQuery] = useState('');
   const [autoRefreshEnabled, setAutoRefreshEnabled] = useState(true);
   const [isAddEntryOpen, setIsAddEntryOpen] = useState(false);
+  const [isTemplateManagerOpen, setIsTemplateManagerOpen] = useState(false);
   const [entryFilter, setEntryFilter] = useState<EntryFilter>('active');
   const isArchivedView = entryFilter === 'archived';
+
+  const sortPromptTemplates = useCallback((templatesToSort: PromptTemplate[]) => (
+    [...templatesToSort].sort((left, right) => left.sort_order - right.sort_order || left.label.localeCompare(right.label))
+  ), []);
 
   const fetchEntries = useCallback(async (currentPage: number = 1, append: boolean = false) => {
     try {
@@ -49,8 +59,22 @@ function App() {
     }
   }, [searchQuery, isArchivedView]);
 
+  const fetchPromptTemplates = useCallback(async () => {
+    setPromptTemplatesLoading(true);
+    setPromptTemplatesError(null);
+
+    try {
+      const templates = await entryApi.getPromptTemplates(false);
+      setPromptTemplates(sortPromptTemplates(templates));
+    } catch (error) {
+      console.error('Failed to fetch prompt templates:', error);
+      setPromptTemplatesError('Failed to load prompt templates.');
+    } finally {
+      setPromptTemplatesLoading(false);
+    }
+  }, [sortPromptTemplates]);
+
   useEffect(() => {
-    // Check if user is already authenticated
     if (auth.isAuthenticated()) {
       setIsAuthenticated(true);
     } else {
@@ -58,7 +82,6 @@ function App() {
     }
   }, []);
 
-  // Fetch entries when search query changes
   useEffect(() => {
     if (isAuthenticated) {
       setLoading(true);
@@ -68,7 +91,12 @@ function App() {
     }
   }, [searchQuery, isAuthenticated, fetchEntries, isArchivedView]);
 
-  // Auto-refresh entries when enabled
+  useEffect(() => {
+    if (isAuthenticated) {
+      fetchPromptTemplates();
+    }
+  }, [isAuthenticated, fetchPromptTemplates]);
+
   useEffect(() => {
     if (isAuthenticated && autoRefreshEnabled && page === 1 && !searchQuery && !isArchivedView) {
       const interval = setInterval(() => {
@@ -103,28 +131,28 @@ function App() {
     auth.removeToken();
     setIsAuthenticated(false);
     setEntries([]);
+    setPromptTemplates([]);
+    setPromptTemplatesError(null);
     setSelectedEntry(null);
     setPage(1);
     setSearchQuery('');
     setIsAddEntryOpen(false);
+    setIsTemplateManagerOpen(false);
     setEntryFilter('active');
   };
 
   const handleDeleteEntry = async (entry: Entry) => {
     try {
       await entryApi.deleteEntry(entry.id);
-
-      // Remove the entry from the local state
       setEntries(prev => prev.filter(e => e.id !== entry.id));
       setTotal(prev => prev - 1);
 
-      // Close chat if this entry was being viewed
       if (selectedEntry?.id === entry.id) {
         setSelectedEntry(null);
       }
     } catch (error) {
       console.error('Failed to delete entry:', error);
-      throw error; // Re-throw to let the component handle the error display
+      throw error;
     }
   };
 
@@ -132,7 +160,7 @@ function App() {
     setIsLoadingMore(true);
     const nextPage = page + 1;
     setPage(nextPage);
-    setAutoRefreshEnabled(false); // Disable auto-refresh when paginating
+    setAutoRefreshEnabled(false);
     fetchEntries(nextPage, true);
   };
 
@@ -164,16 +192,31 @@ function App() {
     setTotal(prev => Math.max(prev - 1, 0));
   };
 
+  const handleCreatePromptTemplate = async (template: PromptTemplateCreate) => {
+    const createdTemplate = await entryApi.createPromptTemplate(template);
+    setPromptTemplates(prev => sortPromptTemplates([...prev, createdTemplate]));
+  };
+
+  const handleUpdatePromptTemplate = async (id: string, template: PromptTemplateUpdate) => {
+    const updatedTemplate = await entryApi.updatePromptTemplate(id, template);
+    setPromptTemplates(prev => sortPromptTemplates(
+      prev.map(currentTemplate => currentTemplate.id === id ? updatedTemplate : currentTemplate)
+    ));
+  };
+
+  const handleDeletePromptTemplate = async (id: string) => {
+    await entryApi.deletePromptTemplate(id);
+    setPromptTemplates(prev => prev.filter(template => template.id !== id));
+  };
+
   const hasMore = entries.length < total;
 
-  // Show login screen if not authenticated
   if (!isAuthenticated) {
     return <Login onLogin={handleLogin} />;
   }
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Header */}
       <header className="bg-white border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
@@ -198,7 +241,7 @@ function App() {
               </div>
               <button
                 onClick={handleLogout}
-                className="flex items-center space-x-2 text-gray-600 hover:text-gray-900 transition-colors"
+                className="flex items-center space-x-2 text-gray-600 transition-colors hover:text-gray-900"
                 title="Logout"
               >
                 <LogOut className="h-4 w-4" />
@@ -209,7 +252,6 @@ function App() {
         </div>
       </header>
 
-      {/* Main content */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="space-y-8">
           <div className="flex flex-col gap-3 md:flex-row md:items-center">
@@ -243,7 +285,7 @@ function App() {
             </div>
             <button
               onClick={() => setIsAddEntryOpen(true)}
-              className="inline-flex items-center justify-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition-colors font-medium"
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary-600 px-4 py-2 font-medium text-white transition-colors hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
               aria-label="Add new entry"
             >
               <Plus className="h-4 w-4" />
@@ -251,7 +293,6 @@ function App() {
             </button>
           </div>
 
-          {/* Entry list */}
           {loading ? (
             <div className="text-center py-12">
               <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mx-auto"></div>
@@ -275,7 +316,6 @@ function App() {
         </div>
       </main>
 
-      {/* Add entry modal */}
       {isAddEntryOpen && (
         <EntryForm
           onEntryCreated={handleEntryCreated}
@@ -283,13 +323,36 @@ function App() {
         />
       )}
 
-      {/* Chat interface modal */}
       {selectedEntry && (
         <ChatInterface
           entry={selectedEntry}
           onClose={handleCloseChat}
         />
       )}
+
+      <button
+        onClick={() => setIsTemplateManagerOpen(true)}
+        className="fixed z-30 inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-gray-700 shadow-lg transition-colors hover:bg-gray-50"
+        style={{
+          left: 'max(1rem, env(safe-area-inset-left))',
+          bottom: 'max(1rem, env(safe-area-inset-bottom))',
+        }}
+        aria-label="Open prompt template settings"
+      >
+        <Settings className="h-4 w-4" />
+        <span>Templates</span>
+      </button>
+
+      <PromptTemplateManager
+        templates={promptTemplates}
+        isOpen={isTemplateManagerOpen}
+        isLoading={promptTemplatesLoading}
+        error={promptTemplatesError}
+        onClose={() => setIsTemplateManagerOpen(false)}
+        onCreate={handleCreatePromptTemplate}
+        onUpdate={handleUpdatePromptTemplate}
+        onDelete={handleDeletePromptTemplate}
+      />
     </div>
   );
 }

--- a/ui/src/components/ChatInterface.test.tsx
+++ b/ui/src/components/ChatInterface.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { ChatInterface } from './ChatInterface';
+
+const { getPromptTemplates, chatWithEntry } = vi.hoisted(() => ({
+  getPromptTemplates: vi.fn(),
+  chatWithEntry: vi.fn(),
+}));
+
+vi.mock('../services/api', () => ({
+  entryApi: {
+    getPromptTemplates,
+    chatWithEntry,
+  },
+}));
+
+const readyEntry = {
+  id: 'entry-1',
+  title: 'Quarterly Review',
+  source_type: 'upload' as const,
+  status: 'READY' as const,
+  archived: false,
+  transcript: 'Transcript content',
+  created_at: '2026-04-03T10:00:00Z',
+  updated_at: '2026-04-03T10:00:00Z',
+};
+
+describe('ChatInterface prompt templates', () => {
+  beforeEach(() => {
+    getPromptTemplates.mockResolvedValue([
+      {
+        id: 'template-1',
+        label: 'Action items',
+        preview_text: 'Extract decisions and owners',
+        body_markdown: '## Action Items\n- List action items',
+        sort_order: 10,
+        is_active: true,
+        created_at: '2026-04-03T00:00:00Z',
+        updated_at: '2026-04-03T00:00:00Z',
+      },
+    ]);
+    chatWithEntry.mockResolvedValue({
+      message: 'Done',
+      timestamp: '2026-04-03T10:00:00Z',
+    });
+  });
+
+  it('supports preview, prefill, and immediate send for prompt templates', async () => {
+    render(<ChatInterface entry={readyEntry} onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Action items')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview Action items' }));
+    expect(screen.getByText('Action Items')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use Only Action items' }));
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toHaveValue('## Action Items\n- List action items');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use & Send Action items' }));
+
+    await waitFor(() => {
+      expect(chatWithEntry).toHaveBeenCalledWith('entry-1', expect.objectContaining({
+        message: '## Action Items\n- List action items',
+      }));
+    });
+  });
+});

--- a/ui/src/components/ChatInterface.tsx
+++ b/ui/src/components/ChatInterface.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Send, X, FileText, AlertCircle, Eye, EyeOff, Copy, Check } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
-import { Entry, ChatMessage } from '../types';
+import { Entry, ChatMessage, PromptTemplate } from '../types';
 import { entryApi } from '../services/api';
+import { PromptTemplatePreviewModal } from './PromptTemplatePreviewModal';
 
 interface ChatInterfaceProps {
   entry: Entry;
@@ -21,6 +22,10 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({ entry, onClose }) 
   const [inputValue, setInputValue] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [promptTemplates, setPromptTemplates] = useState<PromptTemplate[]>([]);
+  const [isLoadingTemplates, setIsLoadingTemplates] = useState(false);
+  const [promptTemplatesError, setPromptTemplatesError] = useState<string | null>(null);
+  const [previewTemplate, setPreviewTemplate] = useState<PromptTemplate | null>(null);
   const [showTranscript, setShowTranscript] = useState(false);
   const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -50,13 +55,53 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({ entry, onClose }) 
     }
   }, [entry.title, isEntryReady]);
 
-  const handleSendMessage = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!inputValue.trim() || isLoading || !isEntryReady) return;
+  useEffect(() => {
+    let isCurrent = true;
+
+    if (!isEntryReady) {
+      setPromptTemplates([]);
+      setPromptTemplatesError(null);
+      setIsLoadingTemplates(false);
+      return () => {
+        isCurrent = false;
+      };
+    }
+
+    setIsLoadingTemplates(true);
+    setPromptTemplatesError(null);
+
+    entryApi.getPromptTemplates(true)
+      .then((templates) => {
+        if (!isCurrent) {
+          return;
+        }
+        setPromptTemplates(templates);
+      })
+      .catch((templateError) => {
+        console.error('Failed to load prompt templates:', templateError);
+        if (isCurrent) {
+          setPromptTemplates([]);
+          setPromptTemplatesError('Prompt templates are unavailable right now.');
+        }
+      })
+      .finally(() => {
+        if (isCurrent) {
+          setIsLoadingTemplates(false);
+        }
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [entry.id, isEntryReady]);
+
+  const submitMessage = async (content: string) => {
+    const trimmedMessage = content.trim();
+    if (!trimmedMessage || isLoading || !isEntryReady) return;
 
     const userMessage: Message = {
       id: Date.now().toString(),
-      content: inputValue.trim(),
+      content: trimmedMessage,
       sender: 'user',
       timestamp: new Date(),
     };
@@ -67,14 +112,12 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({ entry, onClose }) 
     setError(null);
 
     try {
-      // Prepare conversation history for API
       const conversationHistory: ChatMessage[] = messages.map(msg => ({
         role: msg.sender,
         content: msg.content,
         timestamp: msg.timestamp.toISOString(),
       }));
 
-      // Call the chat API
       const response = await entryApi.chatWithEntry(entry.id, {
         message: userMessage.content,
         conversation_history: conversationHistory,
@@ -88,11 +131,10 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({ entry, onClose }) 
       };
 
       setMessages(prev => [...prev, assistantMessage]);
-    } catch (error) {
-      console.error('Chat error:', error);
+    } catch (chatError) {
+      console.error('Chat error:', chatError);
       setError('Failed to get response. Please try again.');
-      
-      // Add error message to chat
+
       const errorMessage: Message = {
         id: (Date.now() + 1).toString(),
         content: 'I apologize, but I encountered an error while processing your message. Please try again.',
@@ -105,6 +147,11 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({ entry, onClose }) 
     }
   };
 
+  const handleSendMessage = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await submitMessage(inputValue);
+  };
+
   const formatTime = (date: Date) => {
     return date.toLocaleTimeString('en-US', {
       hour: '2-digit',
@@ -115,6 +162,15 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({ entry, onClose }) 
 
   const handleQuestionClick = (question: string) => {
     setInputValue(question);
+  };
+
+  const handleTemplateUse = async (template: PromptTemplate, sendImmediately: boolean) => {
+    if (sendImmediately) {
+      await submitMessage(template.body_markdown);
+      return;
+    }
+
+    setInputValue(template.body_markdown);
   };
 
   const copyToClipboard = async (content: string, messageId: string) => {
@@ -244,7 +300,7 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({ entry, onClose }) 
                   >
                     <div className="text-sm">
                       {message.sender === 'user' ? (
-                        <p>{message.content}</p>
+                        <p className="whitespace-pre-wrap">{message.content}</p>
                       ) : (
                         <ReactMarkdown
                           components={{
@@ -377,38 +433,103 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({ entry, onClose }) 
 
         {/* Input */}
         <div className="border-t border-gray-200 p-4">
-          <form onSubmit={handleSendMessage} className="flex space-x-2">
-            <input
-              type="text"
+          <form onSubmit={handleSendMessage} className="flex flex-col gap-2 sm:flex-row">
+            <textarea
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}
               placeholder={isEntryReady ? "Ask about the content..." : "Waiting for transcript..."}
               disabled={isLoading || !isEntryReady}
-              className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 disabled:opacity-50"
+              rows={Math.min(Math.max(inputValue.split('\n').length, 2), 6)}
+              className="flex-1 resize-y rounded-md border border-gray-300 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-primary-500 disabled:opacity-50"
             />
             <button
               type="submit"
               disabled={!inputValue.trim() || isLoading || !isEntryReady}
-              className="px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="self-end rounded-md bg-primary-600 px-4 py-2 text-white transition-colors hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:cursor-not-allowed disabled:opacity-50 sm:self-auto"
             >
               <Send className="h-4 w-4" />
             </button>
           </form>
           
           {isEntryReady && messages.length <= 1 && (
-            <div className="mt-3">
-              <p className="text-xs text-gray-500 mb-2">💡 Try asking:</p>
-              <div className="flex flex-wrap gap-2">
-                {suggestedQuestions.map((question, index) => (
-                  <button
-                    key={index}
-                    onClick={() => handleQuestionClick(question)}
-                    disabled={isLoading}
-                    className="px-3 py-1 text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-full border border-gray-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    {question}
-                  </button>
-                ))}
+            <div className="mt-4 space-y-4">
+              <div>
+                <p className="mb-2 text-xs text-gray-500">Quick fill</p>
+                <div className="flex flex-wrap gap-2">
+                  {suggestedQuestions.map((question, index) => (
+                    <button
+                      key={index}
+                      onClick={() => handleQuestionClick(question)}
+                      disabled={isLoading}
+                      className="rounded-full border border-gray-200 bg-gray-100 px-3 py-1 text-xs text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {question}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <div className="mb-2 flex items-center justify-between">
+                  <p className="text-xs text-gray-500">Prompt templates</p>
+                  {isLoadingTemplates && (
+                    <span className="text-[11px] text-gray-400">Loading...</span>
+                  )}
+                </div>
+
+                {promptTemplatesError && (
+                  <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                    {promptTemplatesError}
+                  </div>
+                )}
+
+                {!promptTemplatesError && promptTemplates.length > 0 && (
+                  <div className="grid gap-3 md:grid-cols-2">
+                    {promptTemplates.map((template) => (
+                      <div
+                        key={template.id}
+                        className="rounded-xl border border-gray-200 bg-gray-50/70 p-3"
+                      >
+                        <div className="space-y-1">
+                          <p className="font-medium text-gray-900">{template.label}</p>
+                          <p className="text-sm text-gray-500">
+                            {template.preview_text || 'Reusable markdown prompt'}
+                          </p>
+                        </div>
+                        <div className="mt-3 flex flex-wrap gap-2">
+                          <button
+                            onClick={() => setPreviewTemplate(template)}
+                            disabled={isLoading}
+                            aria-label={`Preview ${template.label}`}
+                            className="rounded-md border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            Preview
+                          </button>
+                          <button
+                            onClick={() => handleTemplateUse(template, false)}
+                            disabled={isLoading}
+                            aria-label={`Use Only ${template.label}`}
+                            className="rounded-md border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            Use Only
+                          </button>
+                          <button
+                            onClick={() => handleTemplateUse(template, true)}
+                            disabled={isLoading}
+                            aria-label={`Use & Send ${template.label}`}
+                            className="rounded-md bg-primary-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            Use &amp; Send
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {!promptTemplatesError && !isLoadingTemplates && promptTemplates.length === 0 && (
+                  <p className="text-sm text-gray-500">No prompt templates are active yet.</p>
+                )}
               </div>
             </div>
           )}
@@ -420,6 +541,13 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({ entry, onClose }) 
           )}
         </div>
       </div>
+
+      <PromptTemplatePreviewModal
+        bodyMarkdown={previewTemplate?.body_markdown ?? ''}
+        isOpen={previewTemplate !== null}
+        title={previewTemplate?.label ?? 'Prompt template preview'}
+        onClose={() => setPreviewTemplate(null)}
+      />
     </div>
   );
 };

--- a/ui/src/components/PromptTemplateManager.test.tsx
+++ b/ui/src/components/PromptTemplateManager.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PromptTemplateManager } from './PromptTemplateManager';
+
+describe('PromptTemplateManager', () => {
+  it('renders templates and opens the add form', () => {
+    render(
+      <PromptTemplateManager
+        templates={[
+          {
+            id: 'template-1',
+            label: 'Action items',
+            preview_text: 'Extract action items',
+            body_markdown: '## Action Items',
+            sort_order: 10,
+            is_active: true,
+            created_at: '2026-04-03T00:00:00Z',
+            updated_at: '2026-04-03T00:00:00Z',
+          },
+        ]}
+        isOpen
+        isLoading={false}
+        error={null}
+        onClose={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Action items')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add template' }));
+
+    expect(screen.getByLabelText('Template label')).toBeInTheDocument();
+    expect(screen.getByLabelText('Markdown body')).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/PromptTemplateManager.tsx
+++ b/ui/src/components/PromptTemplateManager.tsx
@@ -1,0 +1,392 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Pencil, Plus, Settings, Trash2, X } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+
+import { PromptTemplate, PromptTemplateCreate, PromptTemplateUpdate } from '../types';
+import { PromptTemplatePreviewModal } from './PromptTemplatePreviewModal';
+
+interface PromptTemplateManagerProps {
+  templates: PromptTemplate[];
+  isOpen: boolean;
+  isLoading: boolean;
+  error: string | null;
+  onClose: () => void;
+  onCreate: (template: PromptTemplateCreate) => Promise<void> | void;
+  onUpdate: (id: string, template: PromptTemplateUpdate) => Promise<void> | void;
+  onDelete: (id: string) => Promise<void> | void;
+}
+
+interface TemplateFormState {
+  label: string;
+  preview_text: string;
+  body_markdown: string;
+  sort_order: number;
+  is_active: boolean;
+}
+
+const createEmptyForm = (templates: PromptTemplate[]): TemplateFormState => ({
+  label: '',
+  preview_text: '',
+  body_markdown: '',
+  sort_order: templates.length > 0 ? Math.max(...templates.map(template => template.sort_order)) + 10 : 10,
+  is_active: true,
+});
+
+const mapTemplateToForm = (template: PromptTemplate): TemplateFormState => ({
+  label: template.label,
+  preview_text: template.preview_text ?? '',
+  body_markdown: template.body_markdown,
+  sort_order: template.sort_order,
+  is_active: template.is_active,
+});
+
+export const PromptTemplateManager: React.FC<PromptTemplateManagerProps> = ({
+  templates,
+  isOpen,
+  isLoading,
+  error,
+  onClose,
+  onCreate,
+  onUpdate,
+  onDelete,
+}) => {
+  const [editingTemplateId, setEditingTemplateId] = useState<string | null>(null);
+  const [formState, setFormState] = useState<TemplateFormState>(() => createEmptyForm(templates));
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [previewTemplate, setPreviewTemplate] = useState<PromptTemplate | null>(null);
+
+  const sortedTemplates = useMemo(
+    () => [...templates].sort((left, right) => left.sort_order - right.sort_order || left.label.localeCompare(right.label)),
+    [templates]
+  );
+
+  useEffect(() => {
+    if (!isOpen) {
+      setEditingTemplateId(null);
+      setFormState(createEmptyForm(templates));
+      setSubmitError(null);
+      return;
+    }
+
+    if (editingTemplateId === null) {
+      setFormState(createEmptyForm(templates));
+      setSubmitError(null);
+    }
+  }, [isOpen, templates, editingTemplateId]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const resetForm = () => {
+    setEditingTemplateId(null);
+    setFormState(createEmptyForm(templates));
+    setSubmitError(null);
+  };
+
+  const openCreateForm = () => {
+    setEditingTemplateId(null);
+    setFormState(createEmptyForm(templates));
+    setSubmitError(null);
+  };
+
+  const openEditForm = (template: PromptTemplate) => {
+    setEditingTemplateId(template.id);
+    setFormState(mapTemplateToForm(template));
+    setSubmitError(null);
+  };
+
+  const handleChange = <K extends keyof TemplateFormState>(field: K, value: TemplateFormState[K]) => {
+    setFormState(prev => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!formState.label.trim() || !formState.body_markdown.trim()) {
+      setSubmitError('Template label and markdown body are required.');
+      return;
+    }
+
+    const payload = {
+      label: formState.label.trim(),
+      preview_text: formState.preview_text.trim(),
+      body_markdown: formState.body_markdown,
+      sort_order: formState.sort_order,
+      is_active: formState.is_active,
+    };
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      if (editingTemplateId) {
+        await onUpdate(editingTemplateId, payload);
+      } else {
+        await onCreate(payload);
+      }
+      resetForm();
+    } catch (submitFailure) {
+      console.error('Failed to save prompt template:', submitFailure);
+      setSubmitError('Failed to save template. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (templateId: string, label: string) => {
+    if (!window.confirm(`Delete the template "${label}"?`)) {
+      return;
+    }
+
+    try {
+      await onDelete(templateId);
+      if (editingTemplateId === templateId) {
+        resetForm();
+      }
+    } catch (deleteFailure) {
+      console.error('Failed to delete prompt template:', deleteFailure);
+      setSubmitError('Failed to delete template. Please try again.');
+    }
+  };
+
+  const handleToggleActive = async (template: PromptTemplate) => {
+    try {
+      await onUpdate(template.id, { is_active: !template.is_active });
+      if (editingTemplateId === template.id) {
+        setFormState(prev => ({
+          ...prev,
+          is_active: !template.is_active,
+        }));
+      }
+    } catch (updateFailure) {
+      console.error('Failed to update prompt template:', updateFailure);
+      setSubmitError('Failed to update template. Please try again.');
+    }
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/50 p-4">
+        <div className="flex h-[85vh] w-full max-w-6xl flex-col overflow-hidden rounded-2xl bg-white shadow-2xl md:flex-row">
+          <div className="flex w-full flex-col border-b border-gray-200 md:w-[360px] md:border-b-0 md:border-r">
+            <div className="flex items-center justify-between px-5 py-4">
+              <div className="flex items-center gap-3">
+                <div className="rounded-full bg-gray-100 p-2 text-gray-700">
+                  <Settings className="h-5 w-5" />
+                </div>
+                <div>
+                  <h2 className="text-lg font-semibold text-gray-900">Prompt Templates</h2>
+                  <p className="text-sm text-gray-500">Global templates for chat starters</p>
+                </div>
+              </div>
+              <button
+                onClick={onClose}
+                className="rounded-md p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                aria-label="Close prompt templates"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <div className="border-y border-gray-100 px-5 py-3">
+              <button
+                onClick={openCreateForm}
+                className="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-700"
+              >
+                <Plus className="h-4 w-4" />
+                Add template
+              </button>
+            </div>
+
+            <div className="flex-1 overflow-y-auto px-5 py-4">
+              {isLoading && <p className="text-sm text-gray-500">Loading templates...</p>}
+              {!isLoading && error && (
+                <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                  {error}
+                </div>
+              )}
+              {!isLoading && !error && sortedTemplates.length === 0 && (
+                <p className="text-sm text-gray-500">No templates yet.</p>
+              )}
+              <div className="space-y-3">
+                {sortedTemplates.map(template => (
+                  <div
+                    key={template.id}
+                    className={`rounded-xl border p-3 transition-colors ${
+                      editingTemplateId === template.id ? 'border-primary-300 bg-primary-50/50' : 'border-gray-200'
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="font-medium text-gray-900">{template.label}</p>
+                        <p className="mt-1 text-sm text-gray-500">
+                          {template.preview_text || 'No preview text'}
+                        </p>
+                      </div>
+                      <span
+                        className={`rounded-full px-2 py-1 text-[11px] font-medium ${
+                          template.is_active ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'
+                        }`}
+                      >
+                        {template.is_active ? 'Active' : 'Inactive'}
+                      </span>
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <button
+                        onClick={() => openEditForm(template)}
+                        className="inline-flex items-center gap-1 rounded-md border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                      >
+                        <Pencil className="h-3 w-3" />
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => setPreviewTemplate(template)}
+                        className="rounded-md border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                      >
+                        Preview
+                      </button>
+                      <button
+                        onClick={() => handleToggleActive(template)}
+                        className="rounded-md border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                      >
+                        {template.is_active ? 'Disable' : 'Enable'}
+                      </button>
+                      <button
+                        onClick={() => handleDelete(template.id, template.label)}
+                        className="inline-flex items-center gap-1 rounded-md border border-red-200 px-3 py-1.5 text-xs font-medium text-red-700 transition-colors hover:bg-red-50"
+                      >
+                        <Trash2 className="h-3 w-3" />
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-5 py-5 md:px-6">
+            <div className="mb-5">
+              <h3 className="text-lg font-semibold text-gray-900">
+                {editingTemplateId ? 'Edit template' : 'Create template'}
+              </h3>
+              <p className="text-sm text-gray-500">
+                Use markdown for reusable chat prompts. The live preview shows how the content will render.
+              </p>
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label htmlFor="template-label" className="mb-1 block text-sm font-medium text-gray-700">
+                  Template label
+                </label>
+                <input
+                  id="template-label"
+                  value={formState.label}
+                  onChange={(event) => handleChange('label', event.target.value)}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/20"
+                />
+              </div>
+
+              <div>
+                <label htmlFor="template-preview" className="mb-1 block text-sm font-medium text-gray-700">
+                  Preview text
+                </label>
+                <input
+                  id="template-preview"
+                  value={formState.preview_text}
+                  onChange={(event) => handleChange('preview_text', event.target.value)}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/20"
+                  placeholder="Short summary shown in chat"
+                />
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-[160px,1fr]">
+                <div>
+                  <label htmlFor="template-sort-order" className="mb-1 block text-sm font-medium text-gray-700">
+                    Sort order
+                  </label>
+                  <input
+                    id="template-sort-order"
+                    type="number"
+                    value={formState.sort_order}
+                    onChange={(event) => handleChange('sort_order', Number(event.target.value))}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/20"
+                  />
+                </div>
+                <label className="mt-7 inline-flex items-center gap-2 text-sm font-medium text-gray-700">
+                  <input
+                    type="checkbox"
+                    checked={formState.is_active}
+                    onChange={(event) => handleChange('is_active', event.target.checked)}
+                    className="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                  />
+                  Active in chat selector
+                </label>
+              </div>
+
+              <div>
+                <label htmlFor="template-body" className="mb-1 block text-sm font-medium text-gray-700">
+                  Markdown body
+                </label>
+                <textarea
+                  id="template-body"
+                  value={formState.body_markdown}
+                  onChange={(event) => handleChange('body_markdown', event.target.value)}
+                  rows={12}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 font-mono text-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/20"
+                />
+              </div>
+
+              {(submitError || error) && (
+                <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                  {submitError || error}
+                </div>
+              )}
+
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {isSubmitting ? 'Saving...' : editingTemplateId ? 'Save changes' : 'Create template'}
+                </button>
+                <button
+                  type="button"
+                  onClick={resetForm}
+                  className="rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                >
+                  Clear
+                </button>
+              </div>
+            </form>
+
+            <div className="mt-8">
+              <h4 className="text-sm font-semibold uppercase tracking-[0.18em] text-gray-500">Live preview</h4>
+              <div className="prose prose-sm mt-3 max-w-none rounded-xl border border-gray-200 bg-gray-50 px-4 py-4">
+                {formState.body_markdown.trim() ? (
+                  <ReactMarkdown>{formState.body_markdown}</ReactMarkdown>
+                ) : (
+                  <p>Template markdown preview will appear here.</p>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <PromptTemplatePreviewModal
+        bodyMarkdown={previewTemplate?.body_markdown ?? ''}
+        isOpen={previewTemplate !== null}
+        title={previewTemplate?.label ?? 'Template preview'}
+        onClose={() => setPreviewTemplate(null)}
+      />
+    </>
+  );
+};

--- a/ui/src/components/PromptTemplatePreviewModal.tsx
+++ b/ui/src/components/PromptTemplatePreviewModal.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { X } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+
+interface PromptTemplatePreviewModalProps {
+  bodyMarkdown: string;
+  isOpen: boolean;
+  title: string;
+  onClose: () => void;
+}
+
+export const PromptTemplatePreviewModal: React.FC<PromptTemplatePreviewModalProps> = ({
+  bodyMarkdown,
+  isOpen,
+  title,
+  onClose,
+}) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-2xl rounded-xl bg-white shadow-2xl">
+        <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4">
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+            <p className="text-sm text-gray-500">Rendered markdown preview</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-md p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+            aria-label="Close preview"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="max-h-[70vh] overflow-y-auto px-5 py-4">
+          <div className="prose prose-sm max-w-none">
+            <ReactMarkdown>{bodyMarkdown}</ReactMarkdown>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/ui/src/services/api.ts
+++ b/ui/src/services/api.ts
@@ -1,5 +1,15 @@
 import axios from 'axios';
-import { Entry, EntryCreate, EntryList, ChatRequest, ChatResponse, SummaryResponse } from '../types';
+import {
+  Entry,
+  EntryCreate,
+  EntryList,
+  ChatRequest,
+  ChatResponse,
+  SummaryResponse,
+  PromptTemplate,
+  PromptTemplateCreate,
+  PromptTemplateUpdate,
+} from '../types';
 
 const api = axios.create({
   baseURL: '/api',
@@ -88,6 +98,30 @@ export const entryApi = {
   setArchived: async (id: string, archived: boolean): Promise<Entry> => {
     const response = await api.put(`/entries/${id}/archive`, { archived });
     return response.data;
+  },
+
+  // Prompt templates
+  getPromptTemplates: async (activeOnly: boolean = false): Promise<PromptTemplate[]> => {
+    const response = await api.get('/prompt-templates/', {
+      params: {
+        active_only: activeOnly,
+      },
+    });
+    return response.data;
+  },
+
+  createPromptTemplate: async (data: PromptTemplateCreate): Promise<PromptTemplate> => {
+    const response = await api.post('/prompt-templates/', data);
+    return response.data;
+  },
+
+  updatePromptTemplate: async (id: string, data: PromptTemplateUpdate): Promise<PromptTemplate> => {
+    const response = await api.put(`/prompt-templates/${id}`, data);
+    return response.data;
+  },
+
+  deletePromptTemplate: async (id: string): Promise<void> => {
+    await api.delete(`/prompt-templates/${id}`);
   },
 
   // Chat with entry

--- a/ui/src/test/setup.ts
+++ b/ui/src/test/setup.ts
@@ -2,6 +2,11 @@ import { cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { afterEach } from 'vitest';
 
+Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+  value: () => {},
+  writable: true,
+});
+
 afterEach(() => {
   cleanup();
 });

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -51,3 +51,30 @@ export interface SummaryResponse {
   summary: string;
   timestamp: string;
 }
+
+export interface PromptTemplate {
+  id: string;
+  label: string;
+  preview_text?: string;
+  body_markdown: string;
+  sort_order: number;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PromptTemplateCreate {
+  label: string;
+  preview_text?: string;
+  body_markdown: string;
+  sort_order?: number;
+  is_active?: boolean;
+}
+
+export interface PromptTemplateUpdate {
+  label?: string;
+  preview_text?: string;
+  body_markdown?: string;
+  sort_order?: number;
+  is_active?: boolean;
+}


### PR DESCRIPTION
introduces a new Prompt Template management feature to both the backend API and the frontend UI. It adds a new `PromptTemplate` model, CRUD API endpoints, service logic, and frontend integration for managing prompt templates. The backend seeds default templates if none exist, and the UI allows authenticated users to view, create, update, and delete prompt templates.