### PR TITLE
Add ability to create entry with existing transcript

### DIFF
--- a/api/app/api/routes/entries.py
+++ b/api/app/api/routes/entries.py
@@ -11,7 +11,7 @@ from loguru import logger
 from app.db.database import get_db
 from app.models.entry import Entry, EntryStatus, SourceType
 from app.models.schemas import (
-    EntryResponse, EntryCreate, EntryStatusUpdate, EntryArchiveUpdate, EntryList,
+    EntryResponse, EntryCreate, EntryTranscriptCreate, EntryStatusUpdate, EntryArchiveUpdate, EntryList,
     ChatRequest, ChatResponse, SummaryResponse
 )
 from app.services.entry_service import EntryService
@@ -112,6 +112,29 @@ async def create_from_url(
     
     # TODO: Start background processing for URL download and ASR
     
+    return EntryResponse.from_orm(entry)
+
+
+@router.post("/transcript", response_model=EntryResponse)
+async def create_from_transcript(
+    entry_data: EntryTranscriptCreate,
+    db: Session = Depends(get_db),
+    current_user: bool = Depends(get_current_user)
+):
+    """Create entry from an existing transcript"""
+
+    transcript = entry_data.transcript.strip()
+    if not transcript:
+        raise HTTPException(status_code=400, detail="transcript is required")
+
+    title = entry_data.title.strip() or "Transcript entry"
+
+    entry_service = EntryService(db)
+    entry = entry_service.create_transcript_entry(
+        title=title,
+        transcript=transcript,
+    )
+
     return EntryResponse.from_orm(entry)
 
 @router.get("/", response_model=EntryList)

--- a/api/app/models/schemas.py
+++ b/api/app/models/schemas.py
@@ -10,6 +10,13 @@ class EntryCreate(BaseModel):
 
     model_config = {"from_attributes": True}
 
+
+class EntryTranscriptCreate(BaseModel):
+    title: str
+    transcript: str = Field(..., min_length=1)
+
+    model_config = {"from_attributes": True}
+
 class EntryUpload(BaseModel):
     title: str
 

--- a/api/app/services/entry_service.py
+++ b/api/app/services/entry_service.py
@@ -18,7 +18,9 @@ class EntryService:
         title: str,
         source_type: SourceType,
         source_url: Optional[str] = None,
-        filename: Optional[str] = None
+        filename: Optional[str] = None,
+        status: EntryStatus = EntryStatus.NEW,
+        transcript: Optional[str] = None,
     ) -> Entry:
         """Create a new entry"""
         
@@ -27,7 +29,8 @@ class EntryService:
             source_type=source_type,
             source_url=source_url,
             filename=filename,
-            status=EntryStatus.NEW
+            status=status,
+            transcript=transcript,
         )
         
         self.db.add(entry)
@@ -35,6 +38,16 @@ class EntryService:
         self.db.refresh(entry)
         
         return entry
+
+    def create_transcript_entry(self, title: str, transcript: str) -> Entry:
+        """Create a ready entry from an existing transcript."""
+
+        return self.create_entry(
+            title=title,
+            source_type=SourceType.UPLOAD,
+            status=EntryStatus.READY,
+            transcript=transcript,
+        )
     
     def get_entry(self, entry_id: UUID) -> Optional[Entry]:
         """Get entry by ID"""

--- a/api/tests/test_entry_transcript.py
+++ b/api/tests/test_entry_transcript.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+from unittest import TestCase
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.models.entry import EntryStatus, SourceType
+from app.services.entry_service import EntryService
+
+
+class EntryServiceTranscriptTests(TestCase):
+    def test_creates_ready_entry_from_existing_transcript(self):
+        from unittest.mock import MagicMock
+
+        db = MagicMock()
+        service = EntryService(db)
+
+        entry = service.create_transcript_entry(
+            title="Board sync",
+            transcript="Already transcribed content",
+        )
+
+        self.assertEqual(entry.title, "Board sync")
+        self.assertEqual(entry.source_type, SourceType.UPLOAD)
+        self.assertEqual(entry.status, EntryStatus.READY)
+        self.assertEqual(entry.transcript, "Already transcribed content")
+        db.add.assert_called_once_with(entry)
+        db.commit.assert_called_once()
+        db.refresh.assert_called_once_with(entry)

--- a/ui/src/components/EntryForm.test.tsx
+++ b/ui/src/components/EntryForm.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { EntryForm } from './EntryForm';
+
+const { createFromTranscript, createFromUrl, uploadFile } = vi.hoisted(() => ({
+  createFromTranscript: vi.fn(),
+  createFromUrl: vi.fn(),
+  uploadFile: vi.fn(),
+}));
+
+vi.mock('../services/api', () => ({
+  entryApi: {
+    createFromTranscript,
+    createFromUrl,
+    uploadFile,
+  },
+}));
+
+describe('EntryForm transcript submission', () => {
+  beforeEach(() => {
+    createFromTranscript.mockReset();
+    createFromUrl.mockReset();
+    uploadFile.mockReset();
+  });
+
+  it('creates an entry from an existing transcript', async () => {
+    const onEntryCreated = vi.fn();
+    const onClose = vi.fn();
+
+    createFromTranscript.mockResolvedValue({
+      id: 'entry-transcript-1',
+      title: 'Board sync',
+      source_type: 'upload',
+      status: 'READY',
+      archived: false,
+      transcript: 'Already transcribed content',
+      created_at: '2026-04-04T00:00:00Z',
+      updated_at: '2026-04-04T00:00:00Z',
+    });
+
+    render(
+      <EntryForm
+        onEntryCreated={onEntryCreated}
+        onClose={onClose}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Transcript'));
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Board sync' } });
+    fireEvent.change(screen.getByLabelText(/Transcript text/i), {
+      target: { value: 'Already transcribed content' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Entry' }));
+
+    await waitFor(() => {
+      expect(createFromTranscript).toHaveBeenCalledWith({
+        title: 'Board sync',
+        transcript: 'Already transcribed content',
+      });
+    });
+
+    expect(onEntryCreated).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'entry-transcript-1',
+      status: 'READY',
+    }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/EntryForm.tsx
+++ b/ui/src/components/EntryForm.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, useState } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
-import { Upload, Link, Loader2, X } from 'lucide-react';
+import { Upload, Link, Loader2, X, FileText } from 'lucide-react';
 import { entryApi } from '../services/api';
 import { Entry } from '../types';
 
@@ -9,15 +9,29 @@ interface EntryFormProps {
   onClose: () => void;
 }
 
-type SubmissionType = 'url' | 'upload';
+type SubmissionType = 'url' | 'upload' | 'transcript';
 
 export const EntryForm: React.FC<EntryFormProps> = ({ onEntryCreated, onClose }) => {
   const [submissionType, setSubmissionType] = useState<SubmissionType>('upload');
   const [title, setTitle] = useState('');
   const [url, setUrl] = useState('');
+  const [transcript, setTranscript] = useState('');
   const [file, setFile] = useState<File | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const getTranscriptFallbackTitle = (rawTranscript: string) => {
+    const firstLine = rawTranscript
+      .split('\n')
+      .map(line => line.trim())
+      .find(Boolean);
+
+    if (!firstLine) {
+      return 'Transcript entry';
+    }
+
+    return firstLine.slice(0, 60);
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -35,6 +49,14 @@ export const EntryForm: React.FC<EntryFormProps> = ({ onEntryCreated, onClose })
           title: title.trim() || new URL(url).hostname,
           source_url: url.trim(),
         });
+      } else if (submissionType === 'transcript') {
+        if (!transcript.trim()) {
+          throw new Error('Transcript text is required');
+        }
+        entry = await entryApi.createFromTranscript({
+          title: title.trim() || getTranscriptFallbackTitle(transcript),
+          transcript: transcript.trim(),
+        });
       } else {
         if (!file) {
           throw new Error('File is required');
@@ -49,6 +71,7 @@ export const EntryForm: React.FC<EntryFormProps> = ({ onEntryCreated, onClose })
 
       setTitle('');
       setUrl('');
+      setTranscript('');
       setFile(null);
       onClose();
     } catch (err: any) {
@@ -98,7 +121,7 @@ export const EntryForm: React.FC<EntryFormProps> = ({ onEntryCreated, onClose })
                 <div className="mb-6 flex items-start justify-between">
                   <div>
                     <Dialog.Title className="text-2xl font-bold text-gray-900">Add New Entry</Dialog.Title>
-                    <p className="mt-1 text-sm text-gray-500">Upload a file or submit a URL for processing.</p>
+                    <p className="mt-1 text-sm text-gray-500">Upload a file, submit a URL, or paste a transcript you already have.</p>
                   </div>
                   <button
                     onClick={onClose}
@@ -135,6 +158,18 @@ export const EntryForm: React.FC<EntryFormProps> = ({ onEntryCreated, onClose })
                       />
                       <Link className="ml-2 h-5 w-5 text-gray-500" />
                       <span className="ml-2 text-sm font-medium text-gray-700">From URL</span>
+                    </label>
+
+                    <label className="flex items-center">
+                      <input
+                        type="radio"
+                        value="transcript"
+                        checked={submissionType === 'transcript'}
+                        onChange={(e) => setSubmissionType(e.target.value as SubmissionType)}
+                        className="h-4 w-4 text-primary-600 border-gray-300 focus:ring-primary-500"
+                      />
+                      <FileText className="ml-2 h-5 w-5 text-gray-500" />
+                      <span className="ml-2 text-sm font-medium text-gray-700">Transcript</span>
                     </label>
                   </div>
                 </div>
@@ -206,6 +241,26 @@ export const EntryForm: React.FC<EntryFormProps> = ({ onEntryCreated, onClose })
                           )}
                         </div>
                       </div>
+                    </div>
+                  )}
+
+                  {submissionType === 'transcript' && (
+                    <div>
+                      <label htmlFor="transcript" className="block text-sm font-medium text-gray-700 mb-1">
+                        Transcript text <span className="text-red-500">*</span>
+                      </label>
+                      <textarea
+                        id="transcript"
+                        value={transcript}
+                        onChange={(e) => setTranscript(e.target.value)}
+                        rows={10}
+                        required
+                        placeholder="Paste your existing transcript here"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                      />
+                      <p className="mt-1 text-sm text-gray-500">
+                        This creates a ready-to-chat entry immediately, without audio processing.
+                      </p>
                     </div>
                   )}
 

--- a/ui/src/services/api.ts
+++ b/ui/src/services/api.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import {
   Entry,
   EntryCreate,
+  EntryTranscriptCreate,
   EntryList,
   ChatRequest,
   ChatResponse,
@@ -86,6 +87,12 @@ export const entryApi = {
         'Content-Type': 'multipart/form-data',
       },
     });
+    return response.data;
+  },
+
+  // Create entry from transcript
+  createFromTranscript: async (data: EntryTranscriptCreate): Promise<Entry> => {
+    const response = await api.post('/entries/transcript', data);
     return response.data;
   },
 

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -21,6 +21,11 @@ export interface EntryCreate {
   source_url?: string;
 }
 
+export interface EntryTranscriptCreate {
+  title: string;
+  transcript: string;
+}
+
 export interface EntryList {
   entries: Entry[];
   total: number;


### PR DESCRIPTION
Adds support for creating new entries directly from existing transcripts, both in the backend API and the frontend user interface. Users can now paste a transcript to immediately create a ready-to-chat entry, bypassing the need for audio processing. The changes include new API endpoints, service methods, schema updates, frontend form enhancements, and corresponding tests.

Implements https://github.com/nezhar/voicevault/issues/1