### PR TITLE
Add nebius as llm provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,12 +51,15 @@ ASR_MODEL=whisper-large-v3-turbo  # Groq models: whisper-large-v3, whisper-large
 WHISPER_ASR_URL=http://localhost:9000  # URL of whisper-asr-webservice instance
 
 # LLM Configuration
-LLM_PROVIDER=groq  # Options: groq, cerebras, ollama
-LLM_MODEL=llama-3.3-70b-versatile  # Groq: llama-3.3-70b-versatile, llama-3.1-70b-versatile | Cerebras: llama-3.3-70b, llama3.1-8b, qwen-3-32b | Ollama: any model you have pulled
+LLM_PROVIDER=groq  # Options: groq, cerebras, ollama, nebius
+LLM_MODEL=llama-3.3-70b-versatile  # Groq: llama-3.3-70b-versatile, llama-3.1-70b-versatile | Cerebras: llama-3.3-70b, llama3.1-8b, qwen-3-32b | Ollama: any model you have pulled | Nebius: meta-llama/Meta-Llama-3.1-70B-Instruct
 
 # Ollama Configuration (only needed if LLM_PROVIDER=ollama)
 OLLAMA_BASE_URL=http://localhost:11434  # Ollama server URL
 OLLAMA_MODEL=llama3.2  # Ollama model name (e.g., llama3.2, mistral, codellama)
+
+# Nebius Token Factory Configuration (only needed if LLM_PROVIDER=nebius)
+NEBIUS_API_KEY=your_nebius_api_key_here
 
 # Worker Configuration
 WORKER_INTERVAL=10

--- a/api/.env.example
+++ b/api/.env.example
@@ -2,12 +2,13 @@
 DATABASE_URL=sqlite:///./voicevault.db
 
 # LLM Configuration
-LLM_PROVIDER=groq  # Options: groq, cerebras
-LLM_MODEL=llama-3.3-70b-versatile  # Groq: llama-3.3-70b-versatile, llama-3.1-70b-versatile | Cerebras: llama3.1-70b, llama3.1-8b
+LLM_PROVIDER=groq  # Options: groq, cerebras, ollama, nebius
+LLM_MODEL=llama-3.3-70b-versatile  # Groq: llama-3.3-70b-versatile, llama-3.1-70b-versatile | Cerebras: llama3.1-70b, llama3.1-8b | Nebius: meta-llama/Meta-Llama-3.1-70B-Instruct
 
 # API Keys
 GROQ_API_KEY=your_groq_api_key_here
 CEREBRAS_API_KEY=your_cerebras_api_key_here
+NEBIUS_API_KEY=your_nebius_api_key_here
 HUGGINGFACE_TOKEN=your_huggingface_token_here
 
 # File Storage

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -6,7 +6,7 @@ class LLMProvider(str, Enum):
     GROQ = "groq"
     CEREBRAS = "cerebras"
     OLLAMA = "ollama"
-    # Future: OPENAI = "openai", ANTHROPIC = "anthropic"
+    NEBIUS = "nebius"
 
 class Settings(BaseSettings):
     # Database
@@ -24,6 +24,9 @@ class Settings(BaseSettings):
     # Ollama Configuration
     ollama_base_url: str = "http://localhost:11434"  # Default Ollama URL
     ollama_model: str = "llama3.2"  # Default Ollama model
+
+    # Nebius Configuration
+    nebius_api_key: Optional[str] = None
     
     # Authentication
     access_token: Optional[str] = None  # Global access token for PoC

--- a/api/app/services/chat_service.py
+++ b/api/app/services/chat_service.py
@@ -34,6 +34,15 @@ class ChatService:
             # Override model with Ollama-specific model
             if settings.ollama_model:
                 self.model = settings.ollama_model
+        elif self.provider == LLMProvider.NEBIUS:
+            if not settings.nebius_api_key:
+                raise ValueError("NEBIUS_API_KEY is required for Nebius Token Factory LLM service")
+            # Nebius uses OpenAI-compatible API
+            from openai import OpenAI
+            self.client = OpenAI(
+                api_key=settings.nebius_api_key,
+                base_url="https://api.tokenfactory.nebius.com/v1/"
+            )
         else:
             raise ValueError(f"Unsupported LLM provider: {self.provider}")
         

--- a/worker/.env.example
+++ b/worker/.env.example
@@ -12,12 +12,13 @@ ASR_PROVIDER=groq  # Options: groq
 ASR_MODEL=whisper-large-v3-turbo  # Groq models: whisper-large-v3, whisper-large-v3-turbo
 
 # LLM Configuration
-LLM_PROVIDER=groq  # Options: groq, cerebras
-LLM_MODEL=llama-3.3-70b-versatile  # Groq: llama-3.3-70b-versatile, llama-3.1-70b-versatile | Cerebras: llama3.1-70b, llama3.1-8b
+LLM_PROVIDER=groq  # Options: groq, cerebras, ollama, nebius
+LLM_MODEL=llama-3.3-70b-versatile  # Groq: llama-3.3-70b-versatile, llama-3.1-70b-versatile | Cerebras: llama3.1-70b, llama3.1-8b | Nebius: meta-llama/Meta-Llama-3.1-70B-Instruct
 
 # API Keys
 GROQ_API_KEY=your_groq_api_key_here
 CEREBRAS_API_KEY=your_cerebras_api_key_here
+NEBIUS_API_KEY=your_nebius_api_key_here
 
 # File Storage
 DOWNLOAD_DIR=downloads

--- a/worker/app/core/config.py
+++ b/worker/app/core/config.py
@@ -15,7 +15,7 @@ class LLMProvider(str, Enum):
     GROQ = "groq"
     CEREBRAS = "cerebras"
     OLLAMA = "ollama"
-    # Future: OPENAI = "openai", ANTHROPIC = "anthropic"
+    NEBIUS = "nebius"
 
 class Settings(BaseSettings):
     # Database
@@ -65,6 +65,9 @@ class Settings(BaseSettings):
     # Ollama Configuration
     ollama_base_url: str = "http://localhost:11434"  # Default Ollama URL
     ollama_model: str = "llama3.2"  # Default Ollama model
+
+    # Nebius Configuration
+    nebius_api_key: Optional[str] = None
     
     # Logging
     log_level: str = "INFO"


### PR DESCRIPTION
Adds support for the Nebius LLM provider across the codebase. The changes update configuration files, environment variable examples, and service initialization to enable the use of Nebius's Token Factory as an LLM provider, in addition to existing providers like Groq, Cerebras, and Ollama.
