### PR TITLE
Add metadata modal, rework entry card actions and allow editing entry title

### DIFF
--- a/api/app/api/routes/entries.py
+++ b/api/app/api/routes/entries.py
@@ -11,7 +11,8 @@ from loguru import logger
 from app.db.database import get_db
 from app.models.entry import Entry, EntryStatus, SourceType
 from app.models.schemas import (
-    EntryResponse, EntryCreate, EntryTranscriptCreate, EntryStatusUpdate, EntryArchiveUpdate, EntryList,
+    EntryResponse, EntryCreate, EntryTranscriptCreate, EntryStatusUpdate, EntryArchiveUpdate,
+    EntryMetadataUpdate, EntryList,
     ChatRequest, ChatResponse, SummaryResponse
 )
 from app.services.entry_service import EntryService
@@ -199,6 +200,45 @@ async def update_entry_status(
     if not entry:
         raise HTTPException(status_code=404, detail="Entry not found")
     
+    return EntryResponse.from_orm(entry)
+
+@router.put("/{entry_id}/metadata", response_model=EntryResponse)
+async def update_entry_metadata(
+    entry_id: UUID,
+    metadata_update: EntryMetadataUpdate,
+    db: Session = Depends(get_db),
+    current_user: bool = Depends(get_current_user)
+):
+    """Update title and custom metadata (speakers, additional context) for an entry."""
+
+    title = metadata_update.title.strip() if metadata_update.title else None
+    if metadata_update.title is not None and not title:
+        raise HTTPException(status_code=400, detail="Title cannot be empty.")
+
+    speakers = metadata_update.speakers.strip() if metadata_update.speakers else None
+    additional_context = (
+        metadata_update.additional_context.strip()
+        if metadata_update.additional_context
+        else None
+    )
+
+    if not title and not speakers and not additional_context:
+        raise HTTPException(
+            status_code=400,
+            detail="At least one of 'title', 'speakers', or 'additional_context' must be provided."
+        )
+
+    entry_service = EntryService(db)
+    entry = entry_service.update_entry_metadata(
+        entry_id=entry_id,
+        speakers=speakers or None,
+        additional_context=additional_context or None,
+        title=title,
+    )
+
+    if not entry:
+        raise HTTPException(status_code=404, detail="Entry not found")
+
     return EntryResponse.from_orm(entry)
 
 @router.put("/{entry_id}/archive", response_model=EntryResponse)

--- a/api/app/db/database.py
+++ b/api/app/db/database.py
@@ -24,6 +24,16 @@ def ensure_entry_schema() -> None:
             text("ALTER TABLE entries ADD COLUMN archived BOOLEAN NOT NULL DEFAULT false")
         )
 
+    if "speakers" not in columns:
+        statements.append(
+            text("ALTER TABLE entries ADD COLUMN speakers TEXT")
+        )
+
+    if "additional_context" not in columns:
+        statements.append(
+            text("ALTER TABLE entries ADD COLUMN additional_context TEXT")
+        )
+
     if not statements:
         return
 

--- a/api/app/models/entry.py
+++ b/api/app/models/entry.py
@@ -30,6 +30,8 @@ class Entry(Base):
     archived = Column(Boolean, nullable=False, default=False)
     transcript = Column(Text, nullable=True)
     summary = Column(Text, nullable=True)
+    speakers = Column(Text, nullable=True)
+    additional_context = Column(Text, nullable=True)
     error_message = Column(Text, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/api/app/models/schemas.py
+++ b/api/app/models/schemas.py
@@ -30,6 +30,8 @@ class EntryResponse(BaseModel):
     archived: bool = False
     transcript: Optional[str] = None
     summary: Optional[str] = None
+    speakers: Optional[str] = None
+    additional_context: Optional[str] = None
     error_message: Optional[str] = None
     created_at: datetime
     updated_at: datetime
@@ -42,6 +44,11 @@ class EntryStatusUpdate(BaseModel):
 
 class EntryArchiveUpdate(BaseModel):
     archived: bool
+
+class EntryMetadataUpdate(BaseModel):
+    title: Optional[str] = Field(default=None, min_length=1, max_length=255)
+    speakers: Optional[str] = Field(default=None, max_length=2000)
+    additional_context: Optional[str] = Field(default=None, max_length=5000)
 
 class EntryList(BaseModel):
     entries: list[EntryResponse]

--- a/api/app/services/chat_service.py
+++ b/api/app/services/chat_service.py
@@ -101,8 +101,10 @@ class ChatService:
         """Build the conversation context for the Llama model"""
         
         # System prompt with transcript context
-        system_prompt = f"""You are an AI assistant helping users analyze and discuss voice transcripts. You have access to a transcript from "{entry.title}".
+        metadata_section = self._format_metadata_section(entry)
 
+        system_prompt = f"""You are an AI assistant helping users analyze and discuss voice transcripts. You have access to a transcript from "{entry.title}".
+{metadata_section}
 TRANSCRIPT CONTENT:
 {entry.transcript}
 
@@ -142,14 +144,38 @@ Guidelines:
         
         return messages
     
+    @staticmethod
+    def _format_metadata_section(entry: Entry) -> str:
+        """Render speakers and additional context as a system-prompt section.
+
+        Returns an empty string when both fields are missing/blank, so the
+        prompt stays clean for entries without metadata.
+        """
+
+        speakers = (getattr(entry, "speakers", None) or "").strip()
+        additional_context = (getattr(entry, "additional_context", None) or "").strip()
+
+        if not speakers and not additional_context:
+            return ""
+
+        sections = ["", "ENTRY METADATA:"]
+        if speakers:
+            sections.append(f"Speakers:\n{speakers}")
+        if additional_context:
+            sections.append(f"Additional Context:\n{additional_context}")
+        sections.append("")
+        return "\n".join(sections)
+
     async def generate_summary(self, entry: Entry) -> str:
         """Generate a summary of the entry transcript"""
-        
+
         if not entry.transcript:
             raise ValueError("Entry must have a transcript to summarize")
-        
-        summary_prompt = f"""Please provide a concise summary of this transcript from "{entry.title}":
 
+        metadata_section = self._format_metadata_section(entry)
+
+        summary_prompt = f"""Please provide a concise summary of this transcript from "{entry.title}":
+{metadata_section}
 TRANSCRIPT:
 {entry.transcript}
 

--- a/api/app/services/entry_service.py
+++ b/api/app/services/entry_service.py
@@ -162,6 +162,28 @@ class EntryService:
         
         return entry
     
+    def update_entry_metadata(
+        self,
+        entry_id: UUID,
+        speakers: Optional[str],
+        additional_context: Optional[str],
+        title: Optional[str] = None,
+    ) -> Optional[Entry]:
+        """Update title and custom metadata (speakers, additional context) for an entry."""
+
+        entry = self.get_entry(entry_id)
+        if not entry:
+            return None
+
+        if title is not None:
+            entry.title = title
+        entry.speakers = speakers
+        entry.additional_context = additional_context
+        self.db.commit()
+        self.db.refresh(entry)
+
+        return entry
+
     def update_entry_error(self, entry_id: UUID, error_message: str) -> Optional[Entry]:
         """Update entry with error message"""
         

--- a/api/tests/test_schema_repair.py
+++ b/api/tests/test_schema_repair.py
@@ -14,7 +14,12 @@ class EntrySchemaRepairTests(TestCase):
     def test_adds_archived_column_when_missing(self, inspect_mock, text_mock):
         inspector = MagicMock()
         inspector.get_table_names.return_value = ["entries"]
-        inspector.get_columns.return_value = [{"name": "id"}, {"name": "title"}]
+        inspector.get_columns.return_value = [
+            {"name": "id"},
+            {"name": "title"},
+            {"name": "speakers"},
+            {"name": "additional_context"},
+        ]
         inspect_mock.return_value = inspector
 
         connection = MagicMock()
@@ -30,11 +35,45 @@ class EntrySchemaRepairTests(TestCase):
         )
         connection.execute.assert_called_once()
 
+    @patch("app.db.database.text", side_effect=lambda statement: statement)
     @patch("app.db.database.inspect")
-    def test_skips_when_archived_column_exists(self, inspect_mock):
+    def test_adds_metadata_columns_when_missing(self, inspect_mock, text_mock):
         inspector = MagicMock()
         inspector.get_table_names.return_value = ["entries"]
-        inspector.get_columns.return_value = [{"name": "id"}, {"name": "archived"}]
+        inspector.get_columns.return_value = [
+            {"name": "id"},
+            {"name": "title"},
+            {"name": "archived"},
+        ]
+        inspect_mock.return_value = inspector
+
+        connection = MagicMock()
+        begin_context = MagicMock()
+        begin_context.__enter__.return_value = connection
+        begin_context.__exit__.return_value = None
+
+        with patch.object(database.engine, "begin", return_value=begin_context):
+            database.ensure_entry_schema()
+
+        statements = [call.args[0] for call in text_mock.call_args_list]
+        self.assertIn(
+            "ALTER TABLE entries ADD COLUMN speakers TEXT", statements
+        )
+        self.assertIn(
+            "ALTER TABLE entries ADD COLUMN additional_context TEXT", statements
+        )
+        self.assertEqual(connection.execute.call_count, 2)
+
+    @patch("app.db.database.inspect")
+    def test_skips_when_all_columns_exist(self, inspect_mock):
+        inspector = MagicMock()
+        inspector.get_table_names.return_value = ["entries"]
+        inspector.get_columns.return_value = [
+            {"name": "id"},
+            {"name": "archived"},
+            {"name": "speakers"},
+            {"name": "additional_context"},
+        ]
         inspect_mock.return_value = inspector
 
         begin_mock = MagicMock()

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -4,6 +4,7 @@ import { Mic, Brain, Zap, LogOut, Plus, Settings } from 'lucide-react';
 import { EntryForm } from './components/EntryForm';
 import { EntryList } from './components/EntryList';
 import { ChatInterface } from './components/ChatInterface';
+import { EntryMetadataModal } from './components/EntryMetadataModal';
 import { Login } from './components/Login';
 import { PromptTemplateManager } from './components/PromptTemplateManager';
 import { SearchBar } from './components/SearchBar';
@@ -28,6 +29,7 @@ function App() {
   const [autoRefreshEnabled, setAutoRefreshEnabled] = useState(true);
   const [isAddEntryOpen, setIsAddEntryOpen] = useState(false);
   const [isTemplateManagerOpen, setIsTemplateManagerOpen] = useState(false);
+  const [metadataEntry, setMetadataEntry] = useState<Entry | null>(null);
   const [entryFilter, setEntryFilter] = useState<EntryFilter>('active');
   const isArchivedView = entryFilter === 'archived';
 
@@ -178,6 +180,19 @@ function App() {
     setEntryFilter(filter);
   };
 
+  const handleEditMetadata = (entry: Entry) => {
+    setMetadataEntry(entry);
+  };
+
+  const handleMetadataSaved = (updated: Entry) => {
+    setEntries(prev => prev.map(currentEntry => (
+      currentEntry.id === updated.id ? updated : currentEntry
+    )));
+    if (selectedEntry?.id === updated.id) {
+      setSelectedEntry(updated);
+    }
+  };
+
   const handleToggleArchive = async (entry: Entry, archived: boolean) => {
     const updatedEntry = await entryApi.setArchived(entry.id, archived);
 
@@ -309,6 +324,7 @@ function App() {
               onOpenChat={handleOpenChat}
               onDelete={handleDeleteEntry}
               onToggleArchive={handleToggleArchive}
+              onEditMetadata={handleEditMetadata}
               onLoadMore={handleLoadMore}
               isSearching={!!searchQuery}
             />
@@ -327,6 +343,15 @@ function App() {
         <ChatInterface
           entry={selectedEntry}
           onClose={handleCloseChat}
+        />
+      )}
+
+      {metadataEntry && (
+        <EntryMetadataModal
+          entry={metadataEntry}
+          isOpen={!!metadataEntry}
+          onClose={() => setMetadataEntry(null)}
+          onSaved={handleMetadataSaved}
         />
       )}
 

--- a/ui/src/components/EntryCard.test.tsx
+++ b/ui/src/components/EntryCard.test.tsx
@@ -22,6 +22,7 @@ describe('EntryCard archive actions', () => {
         onOpenChat={vi.fn()}
         onDelete={vi.fn()}
         onToggleArchive={vi.fn()}
+        onEditMetadata={vi.fn()}
       />
     );
 
@@ -35,6 +36,7 @@ describe('EntryCard archive actions', () => {
         onOpenChat={vi.fn()}
         onDelete={vi.fn()}
         onToggleArchive={vi.fn()}
+        onEditMetadata={vi.fn()}
       />
     );
 
@@ -48,6 +50,7 @@ describe('EntryCard archive actions', () => {
         onOpenChat={vi.fn()}
         onDelete={vi.fn()}
         onToggleArchive={vi.fn()}
+        onEditMetadata={vi.fn()}
       />
     );
 

--- a/ui/src/components/EntryCard.tsx
+++ b/ui/src/components/EntryCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { MessageCircle, Clock, CheckCircle, AlertCircle, Upload, Link, Trash2, Archive, RotateCcw } from 'lucide-react';
+import { MessageCircle, Clock, CheckCircle, AlertCircle, Upload, Link, Trash2, Archive, RotateCcw, Tag } from 'lucide-react';
 import { Entry, EntryStatus } from '../types';
 
 interface EntryCardProps {
@@ -7,6 +7,7 @@ interface EntryCardProps {
   onOpenChat: (entry: Entry) => void;
   onDelete: (entry: Entry) => void;
   onToggleArchive: (entry: Entry, archived: boolean) => Promise<void>;
+  onEditMetadata: (entry: Entry) => void;
 }
 
 const getStatusInfo = (status: EntryStatus) => {
@@ -50,13 +51,14 @@ const getStatusInfo = (status: EntryStatus) => {
   }
 };
 
-export const EntryCard: React.FC<EntryCardProps> = ({ entry, onOpenChat, onDelete, onToggleArchive }) => {
+export const EntryCard: React.FC<EntryCardProps> = ({ entry, onOpenChat, onDelete, onToggleArchive, onEditMetadata }) => {
   const [isDeleting, setIsDeleting] = useState(false);
   const [isUpdatingArchive, setIsUpdatingArchive] = useState(false);
   const statusInfo = getStatusInfo(entry.status);
   const StatusIcon = statusInfo.icon;
   const canChat = entry.status === 'READY' && entry.transcript;
   const canToggleArchive = entry.status === 'READY';
+  const hasMetadata = !!(entry.speakers || entry.additional_context);
 
   const handleDelete = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -78,6 +80,13 @@ export const EntryCard: React.FC<EntryCardProps> = ({ entry, onOpenChat, onDelet
 
   const handleArchiveToggle = async (e: React.MouseEvent) => {
     e.stopPropagation();
+
+    const message = entry.archived
+      ? `Unarchive "${entry.title}"?`
+      : `Archive "${entry.title}"? You can unarchive it later.`;
+    if (!confirm(message)) {
+      return;
+    }
 
     setIsUpdatingArchive(true);
     try {
@@ -101,10 +110,27 @@ export const EntryCard: React.FC<EntryCardProps> = ({ entry, onOpenChat, onDelet
   };
 
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-4 hover:shadow-md transition-shadow">
-      {/* Header */}
-      <div className="flex items-start justify-between mb-3">
-        <div className="flex items-center space-x-2 flex-1 min-w-0">
+    <div className="bg-white rounded-lg border border-gray-200 hover:shadow-md transition-shadow flex">
+      {/* Main content */}
+      <div
+        className={`flex-1 min-w-0 p-4 ${canChat ? 'cursor-pointer' : ''}`}
+        onClick={canChat ? () => onOpenChat(entry) : undefined}
+        onKeyDown={
+          canChat
+            ? (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onOpenChat(entry);
+                }
+              }
+            : undefined
+        }
+        role={canChat ? 'button' : undefined}
+        tabIndex={canChat ? 0 : undefined}
+        aria-label={canChat ? `Open chat for ${entry.title}` : undefined}
+      >
+        {/* Header */}
+        <div className="flex items-center space-x-2 mb-3">
           {entry.source_type === 'upload' ? (
             <Upload className="h-4 w-4 text-gray-400 flex-shrink-0" />
           ) : (
@@ -114,78 +140,96 @@ export const EntryCard: React.FC<EntryCardProps> = ({ entry, onOpenChat, onDelet
             {entry.title}
           </h3>
         </div>
-        
-        <div className="flex items-center gap-1 ml-2">
-          {canToggleArchive && (
-            <button
-              onClick={handleArchiveToggle}
-              disabled={isUpdatingArchive}
-              className="flex-shrink-0 p-1 text-gray-400 hover:text-primary-600 transition-colors disabled:opacity-50"
-              title={entry.archived ? 'Unarchive entry' : 'Archive entry'}
-              aria-label={entry.archived ? 'Unarchive entry' : 'Archive entry'}
-            >
-              {entry.archived ? (
-                <RotateCcw className="h-4 w-4" />
-              ) : (
-                <Archive className="h-4 w-4" />
-              )}
-            </button>
-          )}
 
-          <button
-            onClick={handleDelete}
-            disabled={isDeleting}
-            className="flex-shrink-0 p-1 text-gray-400 hover:text-red-600 transition-colors disabled:opacity-50"
-            title="Delete entry"
-            aria-label="Delete entry"
-          >
-            <Trash2 className="h-4 w-4" />
-          </button>
-        </div>
-      </div>
-
-      {/* Status */}
-      <div className="mb-3">
-        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${statusInfo.color}`}>
-          <StatusIcon className="h-3 w-3 mr-1" />
-          {statusInfo.label}
-        </span>
-      </div>
-
-      {/* Content preview */}
-      {entry.transcript && (
+        {/* Status */}
         <div className="mb-3">
-          <p className="text-sm text-gray-600 line-clamp-3">
-            {entry.transcript.substring(0, 120)}
-            {entry.transcript.length > 120 && '...'}
-          </p>
+          <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${statusInfo.color}`}>
+            <StatusIcon className="h-3 w-3 mr-1" />
+            {statusInfo.label}
+          </span>
         </div>
-      )}
 
-      {/* Status message */}
-      {entry.error_message && (
-        <div className={`mb-3 p-2 rounded text-sm ${
-          entry.status === 'ERROR' 
-            ? 'bg-red-50 border border-red-200 text-red-600'
-            : 'bg-blue-50 border border-blue-200 text-blue-600'
-        }`}>
-          {entry.error_message}
+        {/* Content preview */}
+        {entry.transcript && (
+          <div className="mb-3">
+            <p className="text-sm text-gray-600 line-clamp-3">
+              {entry.transcript.substring(0, 120)}
+              {entry.transcript.length > 120 && '...'}
+            </p>
+          </div>
+        )}
+
+        {/* Status message */}
+        {entry.error_message && (
+          <div className={`mb-3 p-2 rounded text-sm ${
+            entry.status === 'ERROR'
+              ? 'bg-red-50 border border-red-200 text-red-600'
+              : 'bg-blue-50 border border-blue-200 text-blue-600'
+          }`}>
+            {entry.error_message}
+          </div>
+        )}
+
+        {/* Footer */}
+        <div className="flex items-center pt-3 border-t border-gray-100">
+          <span className="text-xs text-gray-500">
+            {formatDate(entry.created_at)}
+          </span>
         </div>
-      )}
+      </div>
 
-      {/* Footer */}
-      <div className="flex items-center justify-between pt-3 border-t border-gray-100">
-        <span className="text-xs text-gray-500">
-          {formatDate(entry.created_at)}
-        </span>
-        
+      {/* Action rail */}
+      <div className="flex flex-col items-center gap-1 py-3 px-2 border-l border-gray-100">
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onEditMetadata(entry);
+          }}
+          className={`p-1 transition-colors hover:text-primary-600 ${
+            hasMetadata ? 'text-primary-600' : 'text-gray-400'
+          }`}
+          title={hasMetadata ? 'Edit metadata (set)' : 'Add metadata'}
+          aria-label="Edit entry metadata"
+        >
+          <Tag className="h-4 w-4" />
+        </button>
+
+        {canToggleArchive && (
+          <button
+            onClick={handleArchiveToggle}
+            disabled={isUpdatingArchive}
+            className="p-1 text-gray-400 hover:text-primary-600 transition-colors disabled:opacity-50"
+            title={entry.archived ? 'Unarchive entry' : 'Archive entry'}
+            aria-label={entry.archived ? 'Unarchive entry' : 'Archive entry'}
+          >
+            {entry.archived ? (
+              <RotateCcw className="h-4 w-4" />
+            ) : (
+              <Archive className="h-4 w-4" />
+            )}
+          </button>
+        )}
+
+        <span className="block h-px w-4 bg-gray-200 my-1" aria-hidden="true" />
+
+        <button
+          onClick={handleDelete}
+          disabled={isDeleting}
+          className="p-1 text-gray-400 hover:text-red-600 transition-colors disabled:opacity-50"
+          title="Delete entry"
+          aria-label="Delete entry"
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+
         {canChat && (
           <button
             onClick={() => onOpenChat(entry)}
-            className="inline-flex items-center px-3 py-1.5 text-xs font-medium text-primary-600 bg-primary-50 border border-primary-200 rounded-md hover:bg-primary-100 transition-colors"
+            className="mt-auto p-1.5 text-primary-600 bg-primary-50 border border-primary-200 rounded-md hover:bg-primary-100 transition-colors"
+            title="Chat with transcript"
+            aria-label="Chat with transcript"
           >
-            <MessageCircle className="h-3 w-3 mr-1" />
-            Chat
+            <MessageCircle className="h-4 w-4" />
           </button>
         )}
       </div>

--- a/ui/src/components/EntryList.tsx
+++ b/ui/src/components/EntryList.tsx
@@ -13,6 +13,7 @@ interface EntryListProps {
   onOpenChat: (entry: Entry) => void;
   onDelete: (entry: Entry) => void;
   onToggleArchive: (entry: Entry, archived: boolean) => Promise<void>;
+  onEditMetadata: (entry: Entry) => void;
   onLoadMore: () => void;
   isSearching?: boolean;
 }
@@ -27,6 +28,7 @@ export const EntryList: React.FC<EntryListProps> = ({
   onOpenChat,
   onDelete,
   onToggleArchive,
+  onEditMetadata,
   onLoadMore,
   isSearching = false
 }) => {
@@ -78,6 +80,7 @@ export const EntryList: React.FC<EntryListProps> = ({
             onOpenChat={onOpenChat}
             onDelete={onDelete}
             onToggleArchive={onToggleArchive}
+            onEditMetadata={onEditMetadata}
           />
         ))}
       </div>

--- a/ui/src/components/EntryMetadataModal.tsx
+++ b/ui/src/components/EntryMetadataModal.tsx
@@ -1,0 +1,254 @@
+import React, { Fragment, useEffect, useState } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+import { Loader2, X } from 'lucide-react';
+import { entryApi } from '../services/api';
+import { Entry } from '../types';
+
+const TITLE_MAX = 255;
+const SPEAKERS_MAX = 2000;
+const ADDITIONAL_CONTEXT_MAX = 5000;
+
+interface EntryMetadataModalProps {
+  entry: Entry;
+  isOpen: boolean;
+  onClose: () => void;
+  onSaved: (entry: Entry) => void;
+}
+
+export const EntryMetadataModal: React.FC<EntryMetadataModalProps> = ({
+  entry,
+  isOpen,
+  onClose,
+  onSaved,
+}) => {
+  const [title, setTitle] = useState(entry.title);
+  const [speakers, setSpeakers] = useState(entry.speakers ?? '');
+  const [additionalContext, setAdditionalContext] = useState(entry.additional_context ?? '');
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setTitle(entry.title);
+      setSpeakers(entry.speakers ?? '');
+      setAdditionalContext(entry.additional_context ?? '');
+      setError(null);
+    }
+  }, [isOpen, entry]);
+
+  const trimmedTitle = title.trim();
+  const trimmedSpeakers = speakers.trim();
+  const trimmedContext = additionalContext.trim();
+  const titleEmpty = trimmedTitle.length === 0;
+  const titleOverLimit = title.length > TITLE_MAX;
+  const speakersOverLimit = speakers.length > SPEAKERS_MAX;
+  const contextOverLimit = additionalContext.length > ADDITIONAL_CONTEXT_MAX;
+  const canSubmit =
+    !titleEmpty && !titleOverLimit && !speakersOverLimit && !contextOverLimit && !isSaving;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (titleEmpty) {
+      setError('Title cannot be empty.');
+      return;
+    }
+
+    if (titleOverLimit || speakersOverLimit || contextOverLimit) {
+      setError('One of the fields exceeds its maximum length.');
+      return;
+    }
+
+    setIsSaving(true);
+    setError(null);
+    try {
+      const updated = await entryApi.updateMetadata(entry.id, {
+        title: trimmedTitle,
+        speakers: trimmedSpeakers || undefined,
+        additional_context: trimmedContext || undefined,
+      });
+      onSaved(updated);
+      onClose();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to save metadata.';
+      setError(message);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Transition show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={isSaving ? () => undefined : onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-150"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-100"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/50" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-150"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-100"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-2xl rounded-xl bg-white shadow-2xl">
+                <div className="flex items-start justify-between border-b border-gray-200 px-5 py-4">
+                  <Dialog.Title className="text-lg font-semibold text-gray-900">
+                    Edit entry details
+                  </Dialog.Title>
+                  <button
+                    type="button"
+                    onClick={onClose}
+                    disabled={isSaving}
+                    className="ml-3 rounded-md p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 disabled:opacity-50"
+                    aria-label="Close metadata editor"
+                  >
+                    <X className="h-5 w-5" />
+                  </button>
+                </div>
+
+                <form onSubmit={handleSubmit}>
+                  <div className="space-y-5 px-5 py-4">
+                    <p className="text-sm text-gray-600">
+                      Speakers and additional context are forwarded to the AI as part of the system
+                      prompt during chats and summaries.
+                    </p>
+
+                    <div>
+                      <label
+                        htmlFor="entry-title"
+                        className="block text-sm font-medium text-gray-700"
+                      >
+                        Title
+                      </label>
+                      <input
+                        id="entry-title"
+                        type="text"
+                        value={title}
+                        onChange={(event) => setTitle(event.target.value)}
+                        maxLength={TITLE_MAX + 100}
+                        className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+                      />
+                      <div className="mt-1 flex items-center justify-between text-xs">
+                        <span className={titleEmpty ? 'font-medium text-red-600' : 'text-gray-500'}>
+                          {titleEmpty ? 'Title is required.' : 'The display name for this entry.'}
+                        </span>
+                        <span
+                          className={
+                            titleOverLimit ? 'font-medium text-red-600' : 'text-gray-400'
+                          }
+                        >
+                          {title.length}/{TITLE_MAX}
+                        </span>
+                      </div>
+                    </div>
+
+                    <div>
+                      <label
+                        htmlFor="entry-speakers"
+                        className="block text-sm font-medium text-gray-700"
+                      >
+                        Speakers
+                      </label>
+                      <textarea
+                        id="entry-speakers"
+                        value={speakers}
+                        onChange={(event) => setSpeakers(event.target.value)}
+                        placeholder="e.g. Alice (host), Bob (guest engineer)"
+                        rows={3}
+                        maxLength={SPEAKERS_MAX + 100}
+                        className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+                      />
+                      <div className="mt-1 flex items-center justify-between text-xs">
+                        <span className="text-gray-500">
+                          List the people on the recording, one per line or comma-separated.
+                        </span>
+                        <span
+                          className={
+                            speakersOverLimit ? 'font-medium text-red-600' : 'text-gray-400'
+                          }
+                        >
+                          {speakers.length}/{SPEAKERS_MAX}
+                        </span>
+                      </div>
+                    </div>
+
+                    <div>
+                      <label
+                        htmlFor="entry-additional-context"
+                        className="block text-sm font-medium text-gray-700"
+                      >
+                        Additional context
+                      </label>
+                      <textarea
+                        id="entry-additional-context"
+                        value={additionalContext}
+                        onChange={(event) => setAdditionalContext(event.target.value)}
+                        placeholder="Any background that helps the AI understand this recording — meeting agenda, jargon, project name, etc."
+                        rows={6}
+                        maxLength={ADDITIONAL_CONTEXT_MAX + 100}
+                        className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+                      />
+                      <div className="mt-1 flex items-center justify-between text-xs">
+                        <span className="text-gray-500">
+                          Plain text. Markdown is fine but not rendered.
+                        </span>
+                        <span
+                          className={
+                            contextOverLimit ? 'font-medium text-red-600' : 'text-gray-400'
+                          }
+                        >
+                          {additionalContext.length}/{ADDITIONAL_CONTEXT_MAX}
+                        </span>
+                      </div>
+                    </div>
+
+                    {error && (
+                      <div
+                        role="alert"
+                        className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                      >
+                        {error}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="flex items-center justify-end gap-2 border-t border-gray-200 px-5 py-4">
+                    <button
+                      type="button"
+                      onClick={onClose}
+                      disabled={isSaving}
+                      className="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="submit"
+                      disabled={!canSubmit}
+                      className="inline-flex items-center gap-2 rounded-md bg-primary-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {isSaving && <Loader2 className="h-4 w-4 animate-spin" />}
+                      Save changes
+                    </button>
+                  </div>
+                </form>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+};

--- a/ui/src/services/api.ts
+++ b/ui/src/services/api.ts
@@ -4,6 +4,7 @@ import {
   EntryCreate,
   EntryTranscriptCreate,
   EntryList,
+  EntryMetadataUpdate,
   ChatRequest,
   ChatResponse,
   SummaryResponse,
@@ -104,6 +105,12 @@ export const entryApi = {
   // Archive or unarchive entry
   setArchived: async (id: string, archived: boolean): Promise<Entry> => {
     const response = await api.put(`/entries/${id}/archive`, { archived });
+    return response.data;
+  },
+
+  // Update custom metadata (speakers + additional context)
+  updateMetadata: async (id: string, data: EntryMetadataUpdate): Promise<Entry> => {
+    const response = await api.put(`/entries/${id}/metadata`, data);
     return response.data;
   },
 

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -11,9 +11,17 @@ export interface Entry {
   archived: boolean;
   transcript?: string;
   summary?: string;
+  speakers?: string;
+  additional_context?: string;
   error_message?: string;
   created_at: string;
   updated_at: string;
+}
+
+export interface EntryMetadataUpdate {
+  title?: string;
+  speakers?: string;
+  additional_context?: string;
 }
 
 export interface EntryCreate {

--- a/worker/app/models/entry.py
+++ b/worker/app/models/entry.py
@@ -31,6 +31,8 @@ class Entry(Base):
     archived = Column(Boolean, nullable=False, default=False)
     transcript = Column(Text, nullable=True)
     summary = Column(Text, nullable=True)
+    speakers = Column(Text, nullable=True)
+    additional_context = Column(Text, nullable=True)
     error_message = Column(Text, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)


### PR DESCRIPTION
Introduces support for custom metadata fields (`speakers` and `additional_context`) on entries, allowing users to add, update, and view additional context for transcripts. It updates the backend API, database schema, and frontend UI to support editing and displaying this metadata, and ensures that metadata is included in AI prompts for chat and summarization.