### PR TITLE
Add audio playback, word/segment timestamps and retranscribe option

### DIFF
--- a/api/app/api/routes/entries.py
+++ b/api/app/api/routes/entries.py
@@ -1,9 +1,11 @@
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form, status
+from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, File, Form, status
+from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 from typing import List, Optional
 from uuid import UUID
 from datetime import datetime
 import os
+import re
 import shutil
 from pathlib import Path
 from loguru import logger
@@ -209,7 +211,7 @@ async def update_entry_metadata(
     db: Session = Depends(get_db),
     current_user: bool = Depends(get_current_user)
 ):
-    """Update title and custom metadata (speakers, additional context) for an entry."""
+    """Update title/metadata and optionally requeue the entry for retranscription."""
 
     title = metadata_update.title.strip() if metadata_update.title else None
     if metadata_update.title is not None and not title:
@@ -222,10 +224,14 @@ async def update_entry_metadata(
         else None
     )
 
-    if not title and not speakers and not additional_context:
+    regenerate = metadata_update.regenerate_transcript
+    if not title and not speakers and not additional_context and not regenerate:
         raise HTTPException(
             status_code=400,
-            detail="At least one of 'title', 'speakers', or 'additional_context' must be provided."
+            detail=(
+                "At least one of 'title', 'speakers', 'additional_context', "
+                "or 'regenerate_transcript' must be provided."
+            ),
         )
 
     entry_service = EntryService(db)
@@ -238,6 +244,22 @@ async def update_entry_metadata(
 
     if not entry:
         raise HTTPException(status_code=404, detail="Entry not found")
+
+    if regenerate:
+        if not entry.file_path:
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot regenerate transcript: this entry has no audio file.",
+            )
+        if entry.status in (EntryStatus.NEW, EntryStatus.IN_PROGRESS):
+            raise HTTPException(
+                status_code=409,
+                detail="Cannot regenerate transcript: the entry is already queued or processing.",
+            )
+
+        entry = entry_service.requeue_for_transcription(entry_id)
+        if not entry:
+            raise HTTPException(status_code=404, detail="Entry not found")
 
     return EntryResponse.from_orm(entry)
 
@@ -336,6 +358,100 @@ async def chat_with_entry(
     except Exception as e:
         logger.error(f"Chat error for entry {entry_id}: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to generate chat response")
+
+_RANGE_HEADER = re.compile(r"^bytes=(\d*)-(\d*)$")
+_AUDIO_STREAM_CHUNK = 64 * 1024  # 64 KiB per S3 read
+
+
+@router.get("/{entry_id}/audio")
+async def stream_entry_audio(
+    entry_id: UUID,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: bool = Depends(get_current_user),
+):
+    """Stream the entry's audio file with HTTP Range support."""
+
+    entry_service = EntryService(db)
+    entry = entry_service.get_entry(entry_id)
+    if not entry or not entry.file_path:
+        raise HTTPException(status_code=404, detail="Audio not available for this entry")
+
+    s3_service = S3Service()
+    info = s3_service.get_file_info(entry.file_path)
+    if not info:
+        raise HTTPException(status_code=404, detail="Audio file missing in storage")
+
+    total_size = int(info.get("size") or 0)
+    content_type = info.get("content_type") or "audio/mpeg"
+
+    range_header = request.headers.get("range") or request.headers.get("Range")
+    start = 0
+    end = total_size - 1 if total_size else 0
+    is_partial = False
+
+    if range_header and total_size:
+        match = _RANGE_HEADER.match(range_header.strip())
+        if not match:
+            raise HTTPException(status_code=416, detail="Invalid Range header")
+        start_str, end_str = match.group(1), match.group(2)
+        if start_str:
+            start = int(start_str)
+            end = int(end_str) if end_str else total_size - 1
+        elif end_str:
+            # Suffix range: last N bytes
+            suffix = int(end_str)
+            start = max(total_size - suffix, 0)
+            end = total_size - 1
+        if start > end or end >= total_size:
+            raise HTTPException(
+                status_code=416,
+                detail="Range not satisfiable",
+                headers={"Content-Range": f"bytes */{total_size}"},
+            )
+        is_partial = True
+
+    s3_range = f"bytes={start}-{end}" if total_size else None
+
+    try:
+        kwargs = {
+            "Bucket": s3_service.bucket_name,
+            "Key": entry.file_path,
+        }
+        if s3_range:
+            kwargs["Range"] = s3_range
+        s3_response = s3_service.s3_client.get_object(**kwargs)
+    except Exception as exc:
+        logger.error(f"Failed to fetch audio for entry {entry_id}: {exc}")
+        raise HTTPException(status_code=500, detail="Failed to fetch audio from storage")
+
+    body = s3_response["Body"]
+
+    def iter_chunks():
+        try:
+            while True:
+                chunk = body.read(_AUDIO_STREAM_CHUNK)
+                if not chunk:
+                    break
+                yield chunk
+        finally:
+            body.close()
+
+    headers = {
+        "Accept-Ranges": "bytes",
+        "Content-Length": str(end - start + 1) if total_size else "0",
+        "Cache-Control": "private, max-age=0, no-cache",
+    }
+    if is_partial:
+        headers["Content-Range"] = f"bytes {start}-{end}/{total_size}"
+
+    return StreamingResponse(
+        iter_chunks(),
+        status_code=206 if is_partial else 200,
+        media_type=content_type,
+        headers=headers,
+    )
+
 
 @router.post("/{entry_id}/summary", response_model=SummaryResponse)
 async def generate_entry_summary(

--- a/api/app/db/database.py
+++ b/api/app/db/database.py
@@ -34,6 +34,16 @@ def ensure_entry_schema() -> None:
             text("ALTER TABLE entries ADD COLUMN additional_context TEXT")
         )
 
+    if "transcript_words" not in columns:
+        statements.append(
+            text("ALTER TABLE entries ADD COLUMN transcript_words TEXT")
+        )
+
+    if "transcript_segments" not in columns:
+        statements.append(
+            text("ALTER TABLE entries ADD COLUMN transcript_segments TEXT")
+        )
+
     if not statements:
         return
 

--- a/api/app/models/entry.py
+++ b/api/app/models/entry.py
@@ -29,6 +29,8 @@ class Entry(Base):
     status = Column(SQLEnum(EntryStatus), default=EntryStatus.NEW)
     archived = Column(Boolean, nullable=False, default=False)
     transcript = Column(Text, nullable=True)
+    transcript_words = Column(Text, nullable=True)
+    transcript_segments = Column(Text, nullable=True)
     summary = Column(Text, nullable=True)
     speakers = Column(Text, nullable=True)
     additional_context = Column(Text, nullable=True)

--- a/api/app/models/schemas.py
+++ b/api/app/models/schemas.py
@@ -1,8 +1,26 @@
-from pydantic import BaseModel, Field, HttpUrl
-from typing import Optional
+import json
+
+from pydantic import BaseModel, Field, HttpUrl, computed_field, field_validator
+from typing import Any, List, Optional
 from datetime import datetime
 from uuid import UUID
 from .entry import EntryStatus, SourceType
+
+
+class TranscriptWord(BaseModel):
+    """A single transcribed word with start/end timestamps in seconds (millisecond precision)."""
+
+    word: str
+    start: float
+    end: float
+
+
+class TranscriptSegment(BaseModel):
+    """A transcribed segment (typically a sentence/phrase) with start/end timestamps in seconds."""
+
+    text: str
+    start: float
+    end: float
 
 class EntryCreate(BaseModel):
     title: str
@@ -20,15 +38,35 @@ class EntryTranscriptCreate(BaseModel):
 class EntryUpload(BaseModel):
     title: str
 
+def _parse_json_list(value: Any) -> Any:
+    """Decode JSON-encoded list columns into structured data."""
+    if value is None or isinstance(value, list):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            return json.loads(stripped)
+        except json.JSONDecodeError:
+            return None
+    return value
+
+
 class EntryResponse(BaseModel):
     id: UUID
     title: str
     source_type: SourceType
     source_url: Optional[str] = None
     filename: Optional[str] = None
+    # Internal storage path — pulled from the ORM so we can derive has_audio,
+    # but excluded from API output.
+    file_path: Optional[str] = Field(default=None, exclude=True, repr=False)
     status: EntryStatus
     archived: bool = False
     transcript: Optional[str] = None
+    transcript_words: Optional[List[TranscriptWord]] = None
+    transcript_segments: Optional[List[TranscriptSegment]] = None
     summary: Optional[str] = None
     speakers: Optional[str] = None
     additional_context: Optional[str] = None
@@ -38,6 +76,22 @@ class EntryResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+    @computed_field
+    @property
+    def has_audio(self) -> bool:
+        """True when the entry has a stored audio file ready to stream."""
+        return bool(self.file_path)
+
+    @field_validator("transcript_words", mode="before")
+    @classmethod
+    def _parse_transcript_words(cls, value: Any) -> Any:
+        return _parse_json_list(value)
+
+    @field_validator("transcript_segments", mode="before")
+    @classmethod
+    def _parse_transcript_segments(cls, value: Any) -> Any:
+        return _parse_json_list(value)
 
 class EntryStatusUpdate(BaseModel):
     status: EntryStatus
@@ -49,6 +103,7 @@ class EntryMetadataUpdate(BaseModel):
     title: Optional[str] = Field(default=None, min_length=1, max_length=255)
     speakers: Optional[str] = Field(default=None, max_length=2000)
     additional_context: Optional[str] = Field(default=None, max_length=5000)
+    regenerate_transcript: bool = False
 
 class EntryList(BaseModel):
     entries: list[EntryResponse]

--- a/api/app/services/entry_service.py
+++ b/api/app/services/entry_service.py
@@ -149,6 +149,24 @@ class EntryService:
         
         return entry
     
+    def requeue_for_transcription(self, entry_id: UUID) -> Optional[Entry]:
+        """Clear transcript artifacts and put the entry back in the ASR worker's queue."""
+
+        entry = self.get_entry(entry_id)
+        if not entry:
+            return None
+
+        entry.transcript = None
+        entry.transcript_words = None
+        entry.transcript_segments = None
+        entry.summary = None
+        entry.error_message = None
+        entry.status = EntryStatus.IN_PROGRESS
+        self.db.commit()
+        self.db.refresh(entry)
+
+        return entry
+
     def update_entry_summary(self, entry_id: UUID, summary: str) -> Optional[Entry]:
         """Update entry summary"""
         

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -5,6 +5,7 @@ import { EntryForm } from './components/EntryForm';
 import { EntryList } from './components/EntryList';
 import { ChatInterface } from './components/ChatInterface';
 import { EntryMetadataModal } from './components/EntryMetadataModal';
+import { TranscriptTimestampModal } from './components/TranscriptTimestampModal';
 import { Login } from './components/Login';
 import { PromptTemplateManager } from './components/PromptTemplateManager';
 import { SearchBar } from './components/SearchBar';
@@ -30,6 +31,7 @@ function App() {
   const [isAddEntryOpen, setIsAddEntryOpen] = useState(false);
   const [isTemplateManagerOpen, setIsTemplateManagerOpen] = useState(false);
   const [metadataEntry, setMetadataEntry] = useState<Entry | null>(null);
+  const [timestampEntry, setTimestampEntry] = useState<Entry | null>(null);
   const [entryFilter, setEntryFilter] = useState<EntryFilter>('active');
   const isArchivedView = entryFilter === 'archived';
 
@@ -184,6 +186,10 @@ function App() {
     setMetadataEntry(entry);
   };
 
+  const handleViewTimestamps = (entry: Entry) => {
+    setTimestampEntry(entry);
+  };
+
   const handleMetadataSaved = (updated: Entry) => {
     setEntries(prev => prev.map(currentEntry => (
       currentEntry.id === updated.id ? updated : currentEntry
@@ -325,6 +331,7 @@ function App() {
               onDelete={handleDeleteEntry}
               onToggleArchive={handleToggleArchive}
               onEditMetadata={handleEditMetadata}
+              onViewTimestamps={handleViewTimestamps}
               onLoadMore={handleLoadMore}
               isSearching={!!searchQuery}
             />
@@ -352,6 +359,14 @@ function App() {
           isOpen={!!metadataEntry}
           onClose={() => setMetadataEntry(null)}
           onSaved={handleMetadataSaved}
+        />
+      )}
+
+      {timestampEntry && (
+        <TranscriptTimestampModal
+          entry={timestampEntry}
+          isOpen={!!timestampEntry}
+          onClose={() => setTimestampEntry(null)}
         />
       )}
 

--- a/ui/src/components/ChatInterface.test.tsx
+++ b/ui/src/components/ChatInterface.test.tsx
@@ -20,6 +20,7 @@ const readyEntry = {
   source_type: 'upload' as const,
   status: 'READY' as const,
   archived: false,
+  has_audio: false,
   transcript: 'Transcript content',
   created_at: '2026-04-03T10:00:00Z',
   updated_at: '2026-04-03T10:00:00Z',

--- a/ui/src/components/EntryCard.test.tsx
+++ b/ui/src/components/EntryCard.test.tsx
@@ -12,6 +12,7 @@ const baseEntry: Entry = {
   created_at: '2026-04-03T10:00:00Z',
   updated_at: '2026-04-03T10:00:00Z',
   archived: false,
+  has_audio: false,
 };
 
 describe('EntryCard archive actions', () => {
@@ -23,6 +24,7 @@ describe('EntryCard archive actions', () => {
         onDelete={vi.fn()}
         onToggleArchive={vi.fn()}
         onEditMetadata={vi.fn()}
+        onViewTimestamps={vi.fn()}
       />
     );
 
@@ -37,6 +39,7 @@ describe('EntryCard archive actions', () => {
         onDelete={vi.fn()}
         onToggleArchive={vi.fn()}
         onEditMetadata={vi.fn()}
+        onViewTimestamps={vi.fn()}
       />
     );
 
@@ -51,6 +54,7 @@ describe('EntryCard archive actions', () => {
         onDelete={vi.fn()}
         onToggleArchive={vi.fn()}
         onEditMetadata={vi.fn()}
+        onViewTimestamps={vi.fn()}
       />
     );
 

--- a/ui/src/components/EntryCard.tsx
+++ b/ui/src/components/EntryCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { MessageCircle, Clock, CheckCircle, AlertCircle, Upload, Link, Trash2, Archive, RotateCcw, Tag } from 'lucide-react';
+import { MessageCircle, Clock, CheckCircle, AlertCircle, Upload, Link, Trash2, Archive, RotateCcw, Tag, PlayCircle } from 'lucide-react';
 import { Entry, EntryStatus } from '../types';
 
 interface EntryCardProps {
@@ -8,6 +8,7 @@ interface EntryCardProps {
   onDelete: (entry: Entry) => void;
   onToggleArchive: (entry: Entry, archived: boolean) => Promise<void>;
   onEditMetadata: (entry: Entry) => void;
+  onViewTimestamps: (entry: Entry) => void;
 }
 
 const getStatusInfo = (status: EntryStatus) => {
@@ -51,7 +52,7 @@ const getStatusInfo = (status: EntryStatus) => {
   }
 };
 
-export const EntryCard: React.FC<EntryCardProps> = ({ entry, onOpenChat, onDelete, onToggleArchive, onEditMetadata }) => {
+export const EntryCard: React.FC<EntryCardProps> = ({ entry, onOpenChat, onDelete, onToggleArchive, onEditMetadata, onViewTimestamps }) => {
   const [isDeleting, setIsDeleting] = useState(false);
   const [isUpdatingArchive, setIsUpdatingArchive] = useState(false);
   const statusInfo = getStatusInfo(entry.status);
@@ -59,6 +60,7 @@ export const EntryCard: React.FC<EntryCardProps> = ({ entry, onOpenChat, onDelet
   const canChat = entry.status === 'READY' && entry.transcript;
   const canToggleArchive = entry.status === 'READY';
   const hasMetadata = !!(entry.speakers || entry.additional_context);
+  const hasAudio = !!entry.has_audio;
 
   const handleDelete = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -193,6 +195,20 @@ export const EntryCard: React.FC<EntryCardProps> = ({ entry, onOpenChat, onDelet
         >
           <Tag className="h-4 w-4" />
         </button>
+
+        {hasAudio && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onViewTimestamps(entry);
+            }}
+            className="p-1 text-gray-400 transition-colors hover:text-primary-600"
+            title="Play audio"
+            aria-label="Play audio"
+          >
+            <PlayCircle className="h-4 w-4" />
+          </button>
+        )}
 
         {canToggleArchive && (
           <button

--- a/ui/src/components/EntryList.tsx
+++ b/ui/src/components/EntryList.tsx
@@ -14,6 +14,7 @@ interface EntryListProps {
   onDelete: (entry: Entry) => void;
   onToggleArchive: (entry: Entry, archived: boolean) => Promise<void>;
   onEditMetadata: (entry: Entry) => void;
+  onViewTimestamps: (entry: Entry) => void;
   onLoadMore: () => void;
   isSearching?: boolean;
 }
@@ -29,6 +30,7 @@ export const EntryList: React.FC<EntryListProps> = ({
   onDelete,
   onToggleArchive,
   onEditMetadata,
+  onViewTimestamps,
   onLoadMore,
   isSearching = false
 }) => {
@@ -81,6 +83,7 @@ export const EntryList: React.FC<EntryListProps> = ({
             onDelete={onDelete}
             onToggleArchive={onToggleArchive}
             onEditMetadata={onEditMetadata}
+            onViewTimestamps={onViewTimestamps}
           />
         ))}
       </div>

--- a/ui/src/components/EntryMetadataModal.tsx
+++ b/ui/src/components/EntryMetadataModal.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, useEffect, useState } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
-import { Loader2, X } from 'lucide-react';
+import { Loader2, RefreshCw, X } from 'lucide-react';
 import { entryApi } from '../services/api';
 import { Entry } from '../types';
 
@@ -24,14 +24,21 @@ export const EntryMetadataModal: React.FC<EntryMetadataModalProps> = ({
   const [title, setTitle] = useState(entry.title);
   const [speakers, setSpeakers] = useState(entry.speakers ?? '');
   const [additionalContext, setAdditionalContext] = useState(entry.additional_context ?? '');
+  const [regenerateTranscript, setRegenerateTranscript] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Retranscription only makes sense if the audio is in S3 and the worker
+  // isn't already busy with this entry.
+  const isProcessing = entry.status === 'NEW' || entry.status === 'IN_PROGRESS';
+  const canRegenerate = entry.has_audio && !isProcessing;
 
   useEffect(() => {
     if (isOpen) {
       setTitle(entry.title);
       setSpeakers(entry.speakers ?? '');
       setAdditionalContext(entry.additional_context ?? '');
+      setRegenerateTranscript(false);
       setError(null);
     }
   }, [isOpen, entry]);
@@ -66,6 +73,7 @@ export const EntryMetadataModal: React.FC<EntryMetadataModalProps> = ({
         title: trimmedTitle,
         speakers: trimmedSpeakers || undefined,
         additional_context: trimmedContext || undefined,
+        regenerate_transcript: regenerateTranscript && canRegenerate ? true : undefined,
       });
       onSaved(updated);
       onClose();
@@ -213,6 +221,37 @@ export const EntryMetadataModal: React.FC<EntryMetadataModalProps> = ({
                           {additionalContext.length}/{ADDITIONAL_CONTEXT_MAX}
                         </span>
                       </div>
+                    </div>
+
+                    <div className="rounded-md border border-gray-200 bg-gray-50 p-3">
+                      <label
+                        className={`flex items-start gap-2 text-sm ${
+                          canRegenerate
+                            ? 'cursor-pointer text-gray-700'
+                            : 'cursor-not-allowed text-gray-400'
+                        }`}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={regenerateTranscript && canRegenerate}
+                          disabled={!canRegenerate || isSaving}
+                          onChange={(event) => setRegenerateTranscript(event.target.checked)}
+                          className="mt-0.5 h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500 disabled:opacity-50"
+                        />
+                        <span className="flex-1">
+                          <span className="inline-flex items-center gap-1.5 font-medium">
+                            <RefreshCw className="h-3.5 w-3.5" />
+                            Regenerate transcript on save
+                          </span>
+                          <span className="mt-1 block text-xs">
+                            {!entry.has_audio
+                              ? 'No audio available — there is nothing to transcribe.'
+                              : isProcessing
+                                ? 'This entry is already queued or being processed.'
+                                : 'Replaces the existing transcript by re-running the ASR pipeline. Useful after a model or feature change.'}
+                          </span>
+                        </span>
+                      </label>
                     </div>
 
                     {error && (

--- a/ui/src/components/TranscriptTimestampModal.tsx
+++ b/ui/src/components/TranscriptTimestampModal.tsx
@@ -1,0 +1,464 @@
+import React, { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+import { AlertCircle, Loader2, Lock, Unlock, X } from 'lucide-react';
+import { entryApi } from '../services/api';
+import { Entry, TranscriptSegment, TranscriptWord } from '../types';
+
+interface TranscriptTimestampModalProps {
+  entry: Entry;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+type TranscriptLineKind = 'word' | 'segment';
+
+interface TranscriptLine {
+  start: number;
+  end: number;
+  kind: TranscriptLineKind;
+  // Populated for kind === 'word'
+  words?: TranscriptWord[];
+  // Populated for kind === 'segment'
+  text?: string;
+}
+
+// Whisper word streams have no segment breaks, so we group on long pauses,
+// sentence-ending punctuation, and a time/word ceiling — whichever hits first.
+const LINE_PAUSE_SECONDS = 0.6;
+const LINE_MAX_DURATION_SECONDS = 10;
+const LINE_MAX_WORDS = 18;
+const SENTENCE_END = /[.!?…]["')\]]?$/;
+
+// Window during which scroll events triggered by our own scrollIntoView call
+// should be ignored — anything later is a real user interaction.
+const PROGRAMMATIC_SCROLL_GRACE_MS = 250;
+
+const formatTimestamp = (seconds: number): string => {
+  if (!Number.isFinite(seconds) || seconds < 0) return '00:00';
+  const totalSeconds = Math.floor(seconds);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const secs = totalSeconds % 60;
+  const mm = String(minutes).padStart(2, '0');
+  const ss = String(secs).padStart(2, '0');
+  return hours > 0 ? `${String(hours).padStart(2, '0')}:${mm}:${ss}` : `${mm}:${ss}`;
+};
+
+const groupWordsIntoLines = (words: TranscriptWord[]): TranscriptLine[] => {
+  if (!words.length) return [];
+
+  const lines: TranscriptLine[] = [];
+  let current: TranscriptWord[] = [];
+  let lineStart = words[0].start;
+
+  const flush = () => {
+    if (current.length) {
+      lines.push({
+        start: lineStart,
+        end: current[current.length - 1].end,
+        kind: 'word',
+        words: current,
+      });
+      current = [];
+    }
+  };
+
+  for (let i = 0; i < words.length; i++) {
+    const word = words[i];
+    const previous = current[current.length - 1];
+
+    if (!previous) {
+      lineStart = word.start;
+      current.push(word);
+      continue;
+    }
+
+    const gap = word.start - previous.end;
+    const lineDuration = previous.end - lineStart;
+    const sentenceBreak = SENTENCE_END.test(previous.word.trim());
+
+    if (
+      gap >= LINE_PAUSE_SECONDS ||
+      sentenceBreak ||
+      lineDuration >= LINE_MAX_DURATION_SECONDS ||
+      current.length >= LINE_MAX_WORDS
+    ) {
+      flush();
+      lineStart = word.start;
+    }
+
+    current.push(word);
+  }
+
+  flush();
+  return lines;
+};
+
+const segmentsToLines = (segments: TranscriptSegment[]): TranscriptLine[] =>
+  segments
+    .filter((s) => s.text && s.text.trim().length > 0)
+    .map((segment) => ({
+      start: segment.start,
+      end: segment.end,
+      kind: 'segment' as const,
+      text: segment.text,
+    }));
+
+// Locate the line containing a given audio time. Words have small gaps, so a
+// linear scan with "last line whose start ≤ time" is robust and cheap.
+const findActiveLineIndex = (lines: TranscriptLine[], time: number): number => {
+  if (!lines.length || time < lines[0].start) return -1;
+  let lo = 0;
+  let hi = lines.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (lines[mid].start <= time) lo = mid;
+    else hi = mid - 1;
+  }
+  return lo;
+};
+
+export const TranscriptTimestampModal: React.FC<TranscriptTimestampModalProps> = ({
+  entry,
+  isOpen,
+  onClose,
+}) => {
+  const lines = useMemo<TranscriptLine[]>(() => {
+    if (entry.transcript_words && entry.transcript_words.length > 0) {
+      return groupWordsIntoLines(entry.transcript_words);
+    }
+    if (entry.transcript_segments && entry.transcript_segments.length > 0) {
+      return segmentsToLines(entry.transcript_segments);
+    }
+    return [];
+  }, [entry.transcript_words, entry.transcript_segments]);
+
+  const hasLines = lines.length > 0;
+  const hasPlainTranscript = !hasLines && !!entry.transcript && entry.transcript.trim().length > 0;
+  const hasNothing = !hasLines && !hasPlainTranscript;
+
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const lineRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const programmaticScrollUntilRef = useRef(0);
+
+  const [audioUrl, setAudioUrl] = useState<string | null>(null);
+  const [audioError, setAudioError] = useState<string | null>(null);
+  const [isLoadingAudio, setIsLoadingAudio] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [autoScroll, setAutoScroll] = useState(true);
+
+  const activeLineIndex = useMemo(
+    () => findActiveLineIndex(lines, currentTime),
+    [lines, currentTime],
+  );
+
+  // Load the audio blob when the modal opens. Skip the request entirely if the
+  // entry has no audio attached yet.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    setAudioUrl(null);
+    setAudioError(null);
+    setCurrentTime(0);
+    setAutoScroll(true);
+
+    if (!entry.has_audio) {
+      setIsLoadingAudio(false);
+      return;
+    }
+
+    let cancelled = false;
+    let createdUrl: string | null = null;
+    setIsLoadingAudio(true);
+
+    (async () => {
+      try {
+        const { url } = await entryApi.getAudioBlobUrl(entry.id);
+        if (cancelled) {
+          URL.revokeObjectURL(url);
+          return;
+        }
+        createdUrl = url;
+        setAudioUrl(url);
+      } catch (err) {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : 'Failed to load audio.';
+        setAudioError(message);
+      } finally {
+        if (!cancelled) setIsLoadingAudio(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (createdUrl) URL.revokeObjectURL(createdUrl);
+    };
+  }, [isOpen, entry.id, entry.has_audio]);
+
+  // Reset line refs when the line set changes so we don't keep stale entries.
+  useEffect(() => {
+    lineRefs.current = new Array(lines.length).fill(null);
+  }, [lines.length]);
+
+  // Auto-scroll the active line into view when it changes — but only when the
+  // user hasn't taken over scrolling (autoScroll === true).
+  useEffect(() => {
+    if (!autoScroll) return;
+    if (activeLineIndex < 0) return;
+    const el = lineRefs.current[activeLineIndex];
+    if (!el) return;
+    programmaticScrollUntilRef.current = Date.now() + PROGRAMMATIC_SCROLL_GRACE_MS;
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, [activeLineIndex, autoScroll]);
+
+  const handleTranscriptScroll = useCallback(() => {
+    if (!autoScroll) return;
+    if (Date.now() < programmaticScrollUntilRef.current) return;
+    setAutoScroll(false);
+  }, [autoScroll]);
+
+  const handleTimeUpdate = useCallback(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    setCurrentTime(audio.currentTime);
+  }, []);
+
+  const handleSeekTo = useCallback((time: number) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.currentTime = time;
+    setCurrentTime(time);
+    // A user-initiated seek is an intentional jump; re-enable auto-follow so
+    // the transcript snaps to the new position.
+    setAutoScroll(true);
+    if (audio.paused) {
+      void audio.play().catch(() => {
+        /* autoplay may be blocked — that's fine, user will hit play */
+      });
+    }
+  }, []);
+
+  const handleToggleAutoScroll = useCallback(() => {
+    setAutoScroll((prev) => {
+      const next = !prev;
+      if (next && activeLineIndex >= 0) {
+        // Re-enabling: snap immediately to the active line.
+        const el = lineRefs.current[activeLineIndex];
+        if (el) {
+          programmaticScrollUntilRef.current = Date.now() + PROGRAMMATIC_SCROLL_GRACE_MS;
+          el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+      }
+      return next;
+    });
+  }, [activeLineIndex]);
+
+  const transcriptStats = (() => {
+    if (entry.transcript_words && entry.transcript_words.length > 0) {
+      return `${entry.transcript_words.length.toLocaleString()} words`;
+    }
+    if (entry.transcript_segments && entry.transcript_segments.length > 0) {
+      return `${entry.transcript_segments.length.toLocaleString()} segments`;
+    }
+    return null;
+  })();
+
+  return (
+    <Transition show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-150"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-100"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/50" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-150"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-100"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="flex w-full max-w-3xl max-h-[85vh] flex-col rounded-xl bg-white shadow-2xl">
+                <div className="flex items-start justify-between border-b border-gray-200 px-5 py-4">
+                  <div className="min-w-0">
+                    <Dialog.Title className="text-lg font-semibold text-gray-900">
+                      Audio player
+                    </Dialog.Title>
+                    <p className="mt-0.5 truncate text-sm text-gray-500" title={entry.title}>
+                      {entry.title}
+                      {transcriptStats && (
+                        <span className="ml-2 text-gray-400">• {transcriptStats}</span>
+                      )}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={onClose}
+                    className="ml-3 rounded-md p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                    aria-label="Close audio player"
+                  >
+                    <X className="h-5 w-5" />
+                  </button>
+                </div>
+
+                <div className="flex flex-col gap-3 border-b border-gray-200 bg-gray-50 px-5 py-3">
+                  {!entry.has_audio ? (
+                    <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700">
+                      <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                      <span>Audio is not available for this entry yet.</span>
+                    </div>
+                  ) : audioError ? (
+                    <div className="flex items-start gap-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                      <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                      <span>{audioError}</span>
+                    </div>
+                  ) : isLoadingAudio && !audioUrl ? (
+                    <div className="flex items-center gap-2 text-sm text-gray-500">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Loading audio…
+                    </div>
+                  ) : (
+                    <audio
+                      ref={audioRef}
+                      src={audioUrl ?? undefined}
+                      controls
+                      preload="auto"
+                      onTimeUpdate={handleTimeUpdate}
+                      onSeeked={handleTimeUpdate}
+                      className="w-full"
+                    />
+                  )}
+
+                  {hasLines && (
+                    <div className="flex items-center justify-between gap-3">
+                      <button
+                        type="button"
+                        onClick={handleToggleAutoScroll}
+                        className={`inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors ${
+                          autoScroll
+                            ? 'border-primary-200 bg-primary-50 text-primary-700 hover:bg-primary-100'
+                            : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50'
+                        }`}
+                        aria-pressed={autoScroll}
+                        title={
+                          autoScroll
+                            ? 'Auto-scroll is following audio. It turns off when you scroll manually.'
+                            : 'Auto-scroll is paused. Click to follow audio again.'
+                        }
+                      >
+                        {autoScroll ? <Lock className="h-4 w-4" /> : <Unlock className="h-4 w-4" />}
+                        Auto-scroll: {autoScroll ? 'on' : 'off'}
+                      </button>
+                      <span className="text-xs text-gray-500">
+                        Click [time] to jump
+                        {lines[0]?.kind === 'word' && ' • hover a word for exact range'}
+                      </span>
+                    </div>
+                  )}
+                </div>
+
+                <div
+                  onScroll={handleTranscriptScroll}
+                  className="flex-1 overflow-y-auto px-5 py-4"
+                >
+                  {hasLines ? (
+                    <div className="space-y-1 text-sm leading-relaxed text-gray-800">
+                      {lines.map((line, index) => {
+                        const isActive = index === activeLineIndex;
+                        return (
+                          <div
+                            key={index}
+                            ref={(el) => {
+                              lineRefs.current[index] = el;
+                            }}
+                            className={`flex gap-3 rounded-md px-2 py-1 transition-colors ${
+                              isActive ? 'bg-primary-50 ring-1 ring-primary-200' : ''
+                            }`}
+                          >
+                            <button
+                              type="button"
+                              onClick={() => handleSeekTo(line.start)}
+                              disabled={!audioUrl}
+                              className="select-none whitespace-nowrap pt-0.5 font-mono text-xs font-semibold text-primary-600 tabular-nums hover:underline disabled:cursor-not-allowed disabled:no-underline disabled:opacity-50"
+                              title={`Jump to ${formatTimestamp(line.start)}`}
+                              aria-label={`Jump to ${formatTimestamp(line.start)}`}
+                            >
+                              [{formatTimestamp(line.start)}]
+                            </button>
+                            {line.kind === 'word' && line.words ? (
+                              <p className="flex-1 whitespace-pre-wrap break-words">
+                                {line.words.map((word, wordIndex) => {
+                                  const wordIsActive =
+                                    isActive &&
+                                    currentTime >= word.start &&
+                                    currentTime <= word.end;
+                                  return (
+                                    <span
+                                      key={wordIndex}
+                                      title={`${word.start.toFixed(3)}s – ${word.end.toFixed(3)}s`}
+                                      className={`cursor-help ${
+                                        wordIsActive ? 'font-semibold text-primary-700' : ''
+                                      }`}
+                                    >
+                                      {wordIndex > 0 ? ' ' : ''}
+                                      {word.word}
+                                    </span>
+                                  );
+                                })}
+                              </p>
+                            ) : (
+                              <p className="flex-1 whitespace-pre-wrap break-words">
+                                {line.text}
+                              </p>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  ) : hasPlainTranscript ? (
+                    <div className="space-y-3">
+                      <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700">
+                        Timestamps aren't available for this transcript — only the text is shown
+                        below.
+                      </div>
+                      <p className="whitespace-pre-wrap break-words text-sm leading-relaxed text-gray-800">
+                        {entry.transcript}
+                      </p>
+                    </div>
+                  ) : (
+                    <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-700">
+                      {hasNothing && entry.has_audio
+                        ? 'No transcript is available for this entry yet. You can still play the audio above.'
+                        : 'No transcript is available for this entry.'}
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex items-center justify-end border-t border-gray-200 px-5 py-3">
+                  <button
+                    type="button"
+                    onClick={onClose}
+                    className="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                  >
+                    Close
+                  </button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+};

--- a/ui/src/services/api.ts
+++ b/ui/src/services/api.ts
@@ -149,6 +149,17 @@ export const entryApi = {
     const response = await api.post(`/entries/${id}/summary`);
     return response.data;
   },
+
+  // Fetch the entry's audio as a Blob URL for playback in <audio>.
+  // Returns both the URL (to set as src) and the Blob (in case the caller
+  // wants to download). Caller is responsible for revoking the URL.
+  getAudioBlobUrl: async (id: string): Promise<{ url: string; blob: Blob }> => {
+    const response = await api.get(`/entries/${id}/audio`, {
+      responseType: 'blob',
+    });
+    const blob = response.data as Blob;
+    return { url: URL.createObjectURL(blob), blob };
+  },
 };
 
 export const authApi = {

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -1,6 +1,18 @@
 export type EntryStatus = 'NEW' | 'IN_PROGRESS' | 'READY' | 'COMPLETE' | 'ERROR';
 export type SourceType = 'upload' | 'url';
 
+export interface TranscriptWord {
+  word: string;
+  start: number;
+  end: number;
+}
+
+export interface TranscriptSegment {
+  text: string;
+  start: number;
+  end: number;
+}
+
 export interface Entry {
   id: string;
   title: string;
@@ -9,7 +21,10 @@ export interface Entry {
   filename?: string;
   status: EntryStatus;
   archived: boolean;
+  has_audio: boolean;
   transcript?: string;
+  transcript_words?: TranscriptWord[];
+  transcript_segments?: TranscriptSegment[];
   summary?: string;
   speakers?: string;
   additional_context?: string;
@@ -22,6 +37,7 @@ export interface EntryMetadataUpdate {
   title?: string;
   speakers?: string;
   additional_context?: string;
+  regenerate_transcript?: boolean;
 }
 
 export interface EntryCreate {

--- a/worker/app/models/entry.py
+++ b/worker/app/models/entry.py
@@ -30,6 +30,8 @@ class Entry(Base):
     status = Column(SQLEnum(EntryStatus), default=EntryStatus.NEW)
     archived = Column(Boolean, nullable=False, default=False)
     transcript = Column(Text, nullable=True)
+    transcript_words = Column(Text, nullable=True)
+    transcript_segments = Column(Text, nullable=True)
     summary = Column(Text, nullable=True)
     speakers = Column(Text, nullable=True)
     additional_context = Column(Text, nullable=True)

--- a/worker/app/services/asr_service.py
+++ b/worker/app/services/asr_service.py
@@ -1,6 +1,7 @@
 import os
 import asyncio
-from typing import Optional, Tuple, List
+import subprocess
+from typing import Any, Dict, Optional, Tuple, List
 from groq import Groq
 import httpx
 from loguru import logger
@@ -54,45 +55,50 @@ class ASRService:
             self._audio_chunking_service = AudioChunkingService()
         return self._audio_chunking_service
     
-    async def transcribe_file(self, s3_key: str, entry_id: str) -> Tuple[bool, Optional[str], Optional[str]]:
+    async def transcribe_file(self, s3_key: str, entry_id: str) -> Tuple[bool, Optional[str], Optional[List[Dict[str, Any]]], Optional[List[Dict[str, Any]]], Optional[str]]:
         """
-        Transcribe audio/video file from S3 using Groq API
-        Handles large files by chunking them into smaller pieces
-        
+        Transcribe audio/video file from S3 using the configured ASR provider.
+        Handles large files by chunking them into smaller pieces.
+
         Returns:
-            Tuple[success, transcript, error_message]
+            Tuple[success, transcript_text, words, segments, error_message]
+
+            `words` is a list of {"word", "start", "end"} dicts and `segments`
+            is a list of {"text", "start", "end"} dicts (both in seconds with
+            millisecond precision). Either may be None if the provider did
+            not return that granularity.
         """
-        
+
         # Check if file exists in S3
         if not self.s3_service.file_exists(s3_key):
             error_msg = f"File not found in S3: {s3_key}"
             logger.error(f"Entry {entry_id}: {error_msg}")
-            return False, None, error_msg
-        
+            return False, None, None, None, error_msg
+
         # All files are now MP3 format (uploads are original, downloads are converted in download service)
         transcription_s3_key = s3_key
         logger.info(f"Entry {entry_id}: Using file for transcription (already in MP3 format): {s3_key}")
-        
+
         # Verify the file exists and get its info
         if not self.s3_service.file_exists(transcription_s3_key):
             error_msg = f"File not found in S3: {transcription_s3_key}"
             logger.error(f"Entry {entry_id}: {error_msg}")
-            return False, None, error_msg
-        
+            return False, None, None, None, error_msg
+
         # Get file info for transcription
         file_info = self.s3_service.get_file_info(transcription_s3_key)
         file_size = file_info.get('size', 0) if file_info else 0
-        
+
         logger.info(f"Entry {entry_id}: File size: {file_size} bytes ({file_size / (1024*1024):.1f} MB)")
         logger.info(f"Entry {entry_id}: Groq chunk size limit: {settings.max_file_size} bytes ({settings.max_file_size / (1024*1024):.1f} MB)")
-        
+
         # Download file to temporary location
         temp_file_path = self.s3_service.create_temp_download(transcription_s3_key)
         if not temp_file_path:
             error_msg = f"Failed to download file from S3: {transcription_s3_key}"
             logger.error(f"Entry {entry_id}: {error_msg}")
-            return False, None, error_msg
-        
+            return False, None, None, None, error_msg
+
         try:
             # Whisper ASR webservice has no inherent file limit, so skip chunking
             if self.provider == ASRProvider.WHISPER_ASR:
@@ -110,12 +116,12 @@ class ASRService:
         except Exception as e:
             error_msg = f"Transcription error: {str(e)}"
             logger.error(f"Entry {entry_id}: {error_msg}")
-            return False, None, error_msg
+            return False, None, None, None, error_msg
         finally:
             # Clean up temporary file
             self.s3_service.cleanup_temp_file(temp_file_path)
-    
-    async def _transcribe_single_file(self, temp_file_path: str, entry_id: str) -> Tuple[bool, Optional[str], Optional[str]]:
+
+    async def _transcribe_single_file(self, temp_file_path: str, entry_id: str) -> Tuple[bool, Optional[str], Optional[List[Dict[str, Any]]], Optional[List[Dict[str, Any]]], Optional[str]]:
         """Transcribe a single file that fits within provider limits"""
         try:
             # Safety check: Verify file size is within Groq limits (only for Groq provider)
@@ -125,114 +131,199 @@ class ASRService:
                     logger.warning(f"Entry {entry_id}: File size {file_size} exceeds Groq limit {settings.max_file_size}, falling back to chunking")
                     return await self._transcribe_chunked_file(temp_file_path, entry_id)
                 logger.info(f"Entry {entry_id}: File size {file_size} bytes")
-            
+
             logger.info(f"Entry {entry_id}: Starting single file transcription")
-            
+
             # Run transcription in executor to avoid blocking
             loop = asyncio.get_event_loop()
-            transcript = await loop.run_in_executor(
+            transcript, words, segments = await loop.run_in_executor(
                 None,
                 self._transcribe_sync,
                 temp_file_path,
                 None,
                 entry_id
             )
-            
+
             if transcript:
-                logger.info(f"Entry {entry_id}: Single file transcription completed ({len(transcript)} characters)")
-                return True, transcript, None
+                logger.info(
+                    f"Entry {entry_id}: Single file transcription completed "
+                    f"({len(transcript)} characters, {len(words) if words else 0} words, "
+                    f"{len(segments) if segments else 0} segments)"
+                )
+                return True, transcript, words, segments, None
             else:
                 error_msg = "Empty transcript returned"
                 logger.warning(f"Entry {entry_id}: {error_msg}")
-                return False, None, error_msg
-                
+                return False, None, None, None, error_msg
+
         except Exception as e:
             error_msg = f"Single file transcription error: {str(e)}"
             logger.error(f"Entry {entry_id}: {error_msg}")
-            return False, None, error_msg
-    
-    async def _transcribe_chunked_file(self, temp_file_path: str, entry_id: str) -> Tuple[bool, Optional[str], Optional[str]]:
+            return False, None, None, None, error_msg
+
+    async def _transcribe_chunked_file(self, temp_file_path: str, entry_id: str) -> Tuple[bool, Optional[str], Optional[List[Dict[str, Any]]], Optional[List[Dict[str, Any]]], Optional[str]]:
         """Transcribe a large file by splitting it into chunks"""
         chunk_paths = []
         cleanup_chunks = True
         try:
             logger.info(f"Entry {entry_id}: Starting chunked transcription")
-            
+
             # Split the file into chunks
             chunking_success, chunk_paths, chunking_error = await self.audio_chunking_service.chunk_audio_file(temp_file_path, entry_id)
-            
+
             if not chunking_success:
-                return False, None, f"Failed to chunk audio file: {chunking_error}"
-            
+                return False, None, None, None, f"Failed to chunk audio file: {chunking_error}"
+
             # Check if chunking was actually needed (single file returned)
             if len(chunk_paths) == 1 and chunk_paths[0] == temp_file_path:
                 logger.info(f"Entry {entry_id}: File doesn't need chunking, processing as single file")
                 cleanup_chunks = False  # Don't clean up the original file
                 return await self._transcribe_single_file(temp_file_path, entry_id)
-            
+
             logger.info(f"Entry {entry_id}: Processing {len(chunk_paths)} chunks sequentially (multiple API calls to respect size limits)")
-            
-            # Transcribe each chunk SEQUENTIALLY to avoid rate limits
-            transcripts = []
+
+            # Each chunk's timestamps are reset to 0 by ffmpeg, so we shift by
+            # the cumulative duration of preceding chunks to recover absolute
+            # positions in the original audio.
+            transcripts: List[str] = []
+            all_words: List[Dict[str, Any]] = []
+            all_segments: List[Dict[str, Any]] = []
+            cumulative_offset = 0.0
+            any_words_seen = False
+            any_segments_seen = False
+
             for i, chunk_path in enumerate(chunk_paths):
                 try:
                     chunk_size = os.path.getsize(chunk_path)
                     logger.info(f"Entry {entry_id}: Transcribing chunk {i+1}/{len(chunk_paths)} (size: {chunk_size} bytes, limit: {settings.max_file_size} bytes)")
-                    
+
+                    chunk_duration = await self._probe_audio_duration(chunk_path)
+
                     # Verify chunk size is within limits
                     if chunk_size > settings.max_file_size:
                         logger.error(f"Entry {entry_id}: Chunk {i+1} is still too large: {chunk_size} bytes, skipping")
+                        if chunk_duration is not None:
+                            cumulative_offset += chunk_duration
                         continue
-                    
+
                     logger.info(f"Entry {entry_id}: Sending chunk {i+1}/{len(chunk_paths)} to Groq API (sequential processing)")
-                    
+
                     # Run transcription in executor - SEQUENTIAL, not parallel
                     loop = asyncio.get_event_loop()
-                    chunk_transcript = await loop.run_in_executor(
+                    chunk_transcript, chunk_words, chunk_segments = await loop.run_in_executor(
                         None,
                         self._transcribe_sync,
                         chunk_path,
                         None,
                         f"{entry_id}_chunk_{i+1}"
                     )
-                    
+
                     if chunk_transcript:
                         transcripts.append(chunk_transcript.strip())
-                        logger.info(f"Entry {entry_id}: Chunk {i+1}/{len(chunk_paths)} transcribed successfully ({len(chunk_transcript)} characters)")
+                        logger.info(
+                            f"Entry {entry_id}: Chunk {i+1}/{len(chunk_paths)} transcribed successfully "
+                            f"({len(chunk_transcript)} characters, {len(chunk_words) if chunk_words else 0} words, "
+                            f"{len(chunk_segments) if chunk_segments else 0} segments)"
+                        )
                     else:
                         logger.warning(f"Entry {entry_id}: Chunk {i+1}/{len(chunk_paths)} returned empty transcript")
-                    
+
+                    if chunk_words:
+                        any_words_seen = True
+                        for word in chunk_words:
+                            all_words.append({
+                                "word": word["word"],
+                                "start": round(word["start"] + cumulative_offset, 3),
+                                "end": round(word["end"] + cumulative_offset, 3),
+                            })
+
+                    if chunk_segments:
+                        any_segments_seen = True
+                        for segment in chunk_segments:
+                            all_segments.append({
+                                "text": segment["text"],
+                                "start": round(segment["start"] + cumulative_offset, 3),
+                                "end": round(segment["end"] + cumulative_offset, 3),
+                            })
+
+                    if chunk_duration is not None:
+                        cumulative_offset += chunk_duration
+                    elif chunk_words:
+                        # Fallback: advance offset to the last word's end so subsequent
+                        # chunks aren't stacked on top of this one if duration probing failed.
+                        cumulative_offset = max(cumulative_offset, all_words[-1]["end"])
+                    elif chunk_segments:
+                        cumulative_offset = max(cumulative_offset, all_segments[-1]["end"])
+
                     # Small delay between requests to avoid rate limiting
                     if i < len(chunk_paths) - 1:  # Don't delay after the last chunk
                         await asyncio.sleep(0.5)  # 500ms delay between API calls
-                        
+
                 except Exception as e:
                     logger.error(f"Entry {entry_id}: Error transcribing chunk {i+1}: {str(e)}")
                     # Continue with other chunks even if one fails
                     continue
-            
+
             if not transcripts:
-                return False, None, "No chunks were successfully transcribed"
-            
+                return False, None, None, None, "No chunks were successfully transcribed"
+
             # Combine transcripts with paragraph breaks for readability
             combined_transcript = "\n\n".join(transcripts)
-            
-            logger.info(f"Entry {entry_id}: Chunked transcription completed - {len(transcripts)} successful chunks, {len(combined_transcript)} total characters")
+            combined_words = all_words if any_words_seen else None
+            combined_segments = all_segments if any_segments_seen else None
+
+            logger.info(
+                f"Entry {entry_id}: Chunked transcription completed - {len(transcripts)} successful chunks, "
+                f"{len(combined_transcript)} total characters, "
+                f"{len(combined_words) if combined_words else 0} words, "
+                f"{len(combined_segments) if combined_segments else 0} segments"
+            )
             logger.info(f"Entry {entry_id}: Combined transcript preview: {combined_transcript[:200]}...")
-            logger.info(f"Entry {entry_id}: Returning success=True, transcript_length={len(combined_transcript)}, error=None")
-            return True, combined_transcript, None
-            
+            return True, combined_transcript, combined_words, combined_segments, None
+
         except Exception as e:
             error_msg = f"Chunked transcription error: {str(e)}"
             logger.error(f"Entry {entry_id}: {error_msg}")
-            return False, None, error_msg
+            return False, None, None, None, error_msg
         finally:
             # Clean up chunk files (but not the original file if it wasn't actually chunked)
             if chunk_paths and cleanup_chunks:
                 self.audio_chunking_service.cleanup_chunks(chunk_paths)
+
+    @staticmethod
+    async def _probe_audio_duration(file_path: str) -> Optional[float]:
+        """Return audio duration in seconds via ffprobe, or None on failure."""
+        try:
+            loop = asyncio.get_event_loop()
+            result = await loop.run_in_executor(
+                None,
+                lambda: subprocess.run(
+                    [
+                        "ffprobe",
+                        "-v", "quiet",
+                        "-show_entries", "format=duration",
+                        "-of", "default=noprint_wrappers=1:nokey=1",
+                        file_path,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                ),
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return float(result.stdout.strip())
+        except Exception as e:
+            logger.warning(f"ffprobe duration probe failed for {file_path}: {e}")
+        return None
     
-    def _transcribe_sync(self, file_path: str, s3_key: str = None, entry_id: str = None) -> Optional[str]:
-        """Synchronous transcription function to run in executor"""
+    def _transcribe_sync(self, file_path: str, s3_key: str = None, entry_id: str = None) -> Tuple[Optional[str], Optional[List[Dict[str, Any]]], Optional[List[Dict[str, Any]]]]:
+        """Synchronous transcription returning (text, words, segments).
+
+        Each list element is a dict with timestamps in seconds rounded to
+        millisecond precision. words have shape {"word", "start", "end"} and
+        segments have shape {"text", "start", "end"}. Either list may be None
+        if the provider didn't return that granularity.
+        """
         if self.provider == ASRProvider.GROQ:
             return self._transcribe_groq_sync(file_path, entry_id)
         elif self.provider == ASRProvider.WHISPER_ASR:
@@ -240,8 +331,46 @@ class ASRService:
         else:
             raise ValueError(f"Unsupported ASR provider: {self.provider}")
 
-    def _transcribe_groq_sync(self, file_path: str, entry_id: str = None) -> Optional[str]:
-        """Synchronous Groq transcription"""
+    @staticmethod
+    def _normalize_word_entry(raw: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Normalize a single word entry from a provider into our canonical shape."""
+        token = raw.get("word") if "word" in raw else raw.get("text")
+        if token is None:
+            return None
+        try:
+            start = float(raw["start"])
+            end = float(raw["end"])
+        except (KeyError, TypeError, ValueError):
+            return None
+        # Round to millisecond precision for consistency across providers
+        return {
+            "word": str(token),
+            "start": round(start, 3),
+            "end": round(end, 3),
+        }
+
+    @staticmethod
+    def _normalize_segment_entry(raw: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Normalize a segment entry into {"text", "start", "end"}."""
+        text = raw.get("text")
+        if text is None:
+            return None
+        try:
+            start = float(raw["start"])
+            end = float(raw["end"])
+        except (KeyError, TypeError, ValueError):
+            return None
+        cleaned = str(text).strip()
+        if not cleaned:
+            return None
+        return {
+            "text": cleaned,
+            "start": round(start, 3),
+            "end": round(end, 3),
+        }
+
+    def _transcribe_groq_sync(self, file_path: str, entry_id: str = None) -> Tuple[Optional[str], Optional[List[Dict[str, Any]]], Optional[List[Dict[str, Any]]]]:
+        """Synchronous Groq transcription with word-level timestamps"""
         try:
             # File is already in Groq-compatible format (MP3) after conversion
             file_size = os.path.getsize(file_path)
@@ -249,7 +378,6 @@ class ASRService:
 
             # Check the actual file type using the file command (if available)
             try:
-                import subprocess
                 import shutil
 
                 # Check if 'file' command is available
@@ -272,29 +400,65 @@ class ASRService:
                 file_name = f"audio_{entry_id or 'unknown'}.mp3"
                 logger.info(f"Entry {entry_id or 'unknown'}: Sending to Groq with filename: {file_name}")
 
-                # Call Groq API for transcription with file tuple
-                # The file parameter needs to be a tuple: (filename, file_object, content_type)
+                # Request verbose_json with both word- and segment-level
+                # timestamps so we can fall back to segments when callers don't
+                # need or have word-level granularity.
                 transcription = self.client.audio.transcriptions.create(
                     file=(file_name, audio_file, "audio/mpeg"),
                     model=self.model,
-                    response_format="text",
+                    response_format="verbose_json",
+                    timestamp_granularities=["word", "segment"],
                     temperature=0.0
                 )
 
-                # Handle different response formats
-                if hasattr(transcription, 'text'):
-                    return transcription.text.strip() if transcription.text else None
+                text: Optional[str] = None
+                raw_words: List[Any] = []
+                raw_segments: List[Any] = []
+
+                if hasattr(transcription, "text"):
+                    text = transcription.text.strip() if transcription.text else None
+                    raw_words = list(getattr(transcription, "words", None) or [])
+                    raw_segments = list(getattr(transcription, "segments", None) or [])
+                elif isinstance(transcription, dict):
+                    text = (transcription.get("text") or "").strip() or None
+                    raw_words = list(transcription.get("words") or [])
+                    raw_segments = list(transcription.get("segments") or [])
                 elif isinstance(transcription, str):
-                    return transcription.strip()
-                else:
-                    return str(transcription).strip() if transcription else None
+                    text = transcription.strip() or None
+
+                def _coerce(item: Any) -> Optional[Dict[str, Any]]:
+                    if hasattr(item, "model_dump"):
+                        return item.model_dump()
+                    if hasattr(item, "dict"):
+                        return item.dict()
+                    return item if isinstance(item, dict) else None
+
+                normalized_words: List[Dict[str, Any]] = []
+                for w in raw_words:
+                    coerced = _coerce(w)
+                    if coerced is None:
+                        continue
+                    norm = self._normalize_word_entry(coerced)
+                    if norm is not None:
+                        normalized_words.append(norm)
+
+                normalized_segments: List[Dict[str, Any]] = []
+                for s in raw_segments:
+                    coerced = _coerce(s)
+                    if coerced is None:
+                        continue
+                    norm = self._normalize_segment_entry(coerced)
+                    if norm is not None:
+                        normalized_segments.append(norm)
+
+                return text, (normalized_words or None), (normalized_segments or None)
 
         except Exception as e:
             logger.error(f"Groq API error: {str(e)}")
             raise
 
-    def _transcribe_whisper_asr_sync(self, file_path: str, entry_id: str = None) -> Optional[str]:
-        """Synchronous whisper-asr-webservice transcription"""
+    def _transcribe_whisper_asr_sync(self, file_path: str, entry_id: str = None) -> Tuple[Optional[str], Optional[List[Dict[str, Any]]], Optional[List[Dict[str, Any]]]]:
+        """Synchronous whisper-asr-webservice transcription with word-level timestamps"""
         try:
             file_size = os.path.getsize(file_path)
             logger.info(f"Entry {entry_id or 'unknown'}: Sending file to whisper-asr-webservice - path: {file_path}, size: {file_size} bytes")
@@ -302,7 +466,12 @@ class ASRService:
             with open(file_path, "rb") as audio_file:
                 file_name = os.path.basename(file_path)
                 files = {"audio_file": (file_name, audio_file, "audio/mpeg")}
-                params = {"output": "txt", "encode": "true"}
+                # Request JSON output with word-level timestamps.
+                params = {
+                    "output": "json",
+                    "encode": "true",
+                    "word_timestamps": "true",
+                }
 
                 logger.info(f"Entry {entry_id or 'unknown'}: Sending to whisper-asr-webservice at {self.whisper_asr_url}/asr")
 
@@ -314,9 +483,36 @@ class ASRService:
                 )
                 response.raise_for_status()
 
-                transcript = response.text.strip()
-                logger.info(f"Entry {entry_id or 'unknown'}: whisper-asr-webservice transcription completed ({len(transcript)} characters)")
-                return transcript if transcript else None
+                try:
+                    payload = response.json()
+                except ValueError:
+                    # Older whisper-asr-webservice builds may not honor output=json;
+                    # fall back to raw text without timing data.
+                    transcript = response.text.strip()
+                    logger.warning(
+                        f"Entry {entry_id or 'unknown'}: whisper-asr-webservice returned non-JSON output, "
+                        "word- and segment-level timestamps unavailable"
+                    )
+                    return (transcript or None), None, None
+
+                text = (payload.get("text") or "").strip() or None
+                normalized_words: List[Dict[str, Any]] = []
+                normalized_segments: List[Dict[str, Any]] = []
+                for segment in payload.get("segments") or []:
+                    seg_norm = self._normalize_segment_entry(segment)
+                    if seg_norm is not None:
+                        normalized_segments.append(seg_norm)
+                    for raw_word in segment.get("words") or []:
+                        word_norm = self._normalize_word_entry(raw_word)
+                        if word_norm is not None:
+                            normalized_words.append(word_norm)
+
+                logger.info(
+                    f"Entry {entry_id or 'unknown'}: whisper-asr-webservice transcription completed "
+                    f"({len(text) if text else 0} characters, {len(normalized_words)} words, "
+                    f"{len(normalized_segments)} segments)"
+                )
+                return text, (normalized_words or None), (normalized_segments or None)
 
         except httpx.HTTPStatusError as e:
             logger.error(f"whisper-asr-webservice HTTP error: {e.response.status_code} - {e.response.text}")

--- a/worker/app/services/database.py
+++ b/worker/app/services/database.py
@@ -36,6 +36,16 @@ def ensure_entry_schema() -> None:
             text("ALTER TABLE entries ADD COLUMN archived BOOLEAN NOT NULL DEFAULT false")
         )
 
+    if "transcript_words" not in columns:
+        statements.append(
+            text("ALTER TABLE entries ADD COLUMN transcript_words TEXT")
+        )
+
+    if "transcript_segments" not in columns:
+        statements.append(
+            text("ALTER TABLE entries ADD COLUMN transcript_segments TEXT")
+        )
+
     if not statements:
         return
 

--- a/worker/app/services/entry_service.py
+++ b/worker/app/services/entry_service.py
@@ -1,8 +1,9 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, update
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 import asyncio
+import json
 from loguru import logger
 
 from app.models.entry import Entry, EntryStatus, SourceType
@@ -149,26 +150,49 @@ class EntryService:
         result = await self.db.execute(query)
         return result.scalar_one_or_none()
     
-    async def update_entry_transcript(self, entry_id: UUID, transcript: str) -> bool:
-        """Update entry transcript and mark as READY"""
-        
+    async def update_entry_transcript(
+        self,
+        entry_id: UUID,
+        transcript: str,
+        transcript_words: Optional[List[Dict[str, Any]]] = None,
+        transcript_segments: Optional[List[Dict[str, Any]]] = None,
+    ) -> bool:
+        """Update entry transcript plus word/segment timestamps, then mark as READY"""
+
         try:
+            values: Dict[str, Any] = {
+                "transcript": transcript,
+                "status": EntryStatus.READY,
+                "error_message": None,  # Clear any previous errors
+                "transcript_words": (
+                    json.dumps(transcript_words, ensure_ascii=False)
+                    if transcript_words
+                    else None
+                ),
+                "transcript_segments": (
+                    json.dumps(transcript_segments, ensure_ascii=False)
+                    if transcript_segments
+                    else None
+                ),
+            }
+
             query = (
                 update(Entry)
                 .where(Entry.id == entry_id)
-                .values(
-                    transcript=transcript,
-                    status=EntryStatus.READY,
-                    error_message=None  # Clear any previous errors
-                )
+                .values(**values)
             )
-            
+
             await self.db.execute(query)
             await self.db.commit()
-            
-            logger.info(f"Updated entry {entry_id} transcript and marked as READY ({len(transcript)} chars)")
+
+            logger.info(
+                f"Updated entry {entry_id} transcript and marked as READY "
+                f"({len(transcript)} chars, "
+                f"{len(transcript_words) if transcript_words else 0} words, "
+                f"{len(transcript_segments) if transcript_segments else 0} segments)"
+            )
             return True
-            
+
         except Exception as e:
             logger.error(f"Failed to update transcript for entry {entry_id}: {str(e)}")
             await self.db.rollback()

--- a/worker/app/services/worker_service.py
+++ b/worker/app/services/worker_service.py
@@ -170,18 +170,23 @@ class WorkerService:
             
             # Perform transcription (file_path contains S3 key)
             logger.info(f"Entry {entry.id}: Starting transcription process")
-            success, transcript, error_msg = await self.asr_service.transcribe_file(
+            success, transcript, words, segments, error_msg = await self.asr_service.transcribe_file(
                 entry.file_path,
                 str(entry.id)
             )
-            
+
             # Debug logging to see what's returned
-            logger.info(f"Entry {entry.id}: Transcription result - success: {success}, transcript_length: {len(transcript) if transcript else 0}, error: {error_msg}")
-            
+            logger.info(
+                f"Entry {entry.id}: Transcription result - success: {success}, "
+                f"transcript_length: {len(transcript) if transcript else 0}, "
+                f"words: {len(words) if words else 0}, "
+                f"segments: {len(segments) if segments else 0}, error: {error_msg}"
+            )
+
             if success and transcript:
                 # Save transcript and mark as READY
                 logger.info(f"Entry {entry.id}: Transcription successful, saving transcript ({len(transcript)} characters)")
-                await entry_service.update_entry_transcript(entry.id, transcript)
+                await entry_service.update_entry_transcript(entry.id, transcript, words, segments)
                 logger.info(f"Successfully transcribed entry {entry.id}")
             else:
                 # Debug why transcription failed


### PR DESCRIPTION
Introduces audio streaming support, transcript word/segment metadata, and related UI enhancements for entries. The backend now supports streaming entry audio files with HTTP Range requests, and stores detailed transcript timing data. The frontend surfaces a "play audio" button for entries with audio and adds a modal for viewing transcript timestamps. The API and models are updated to support these features, including the ability to requeue an entry for retranscription.

These changes enable users to stream entry audio, view detailed transcript timing information, and requeue entries for retranscription, improving the application's audio and transcript handling capabilities.