### PR TITLE
System prompt manager

### DIFF
--- a/api/app/api/routes/entries.py
+++ b/api/app/api/routes/entries.py
@@ -1,13 +1,17 @@
-from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, File, Form
+from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, File, Form, status
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
+from typing import List, Optional
 from uuid import UUID
 from datetime import datetime
+import os
 import re
+import shutil
+from pathlib import Path
 from loguru import logger
 
 from app.db.database import get_db
-from app.models.entry import EntryStatus, SourceType
+from app.models.entry import Entry, EntryStatus, SourceType
 from app.models.schemas import (
     EntryResponse,
     EntryCreate,
@@ -24,11 +28,11 @@ from app.models.schemas import (
 from app.services.entry_service import EntryService
 from app.services.s3_service import S3Service
 from app.services.chat_service import ChatService
+from app.services.system_prompt_service import SystemPromptService
 from app.core.config import settings
 from app.core.auth import get_current_user
 
 router = APIRouter()
-
 
 @router.post("/upload", response_model=EntryResponse)
 async def upload_file(
@@ -36,35 +40,33 @@ async def upload_file(
     file: UploadFile = File(...),
     language: str | None = Form(default=None),
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user),
+    current_user: bool = Depends(get_current_user)
 ):
     """Upload audio or video file"""
 
     language = _normalize_language(language)
 
     # Validate file type
-    file_extension = file.filename.split(".")[-1].lower()
-    supported_formats = (
-        settings.supported_audio_formats + settings.supported_video_formats
-    )
-
+    file_extension = file.filename.split('.')[-1].lower()
+    supported_formats = settings.supported_audio_formats + settings.supported_video_formats
+    
     if file_extension not in supported_formats:
         raise HTTPException(
             status_code=400,
-            detail=f"Unsupported file format. Supported: {', '.join(supported_formats)}",
+            detail=f"Unsupported file format. Supported: {', '.join(supported_formats)}"
         )
-
+    
     # Validate file size
     file.file.seek(0, 2)  # Seek to end
     file_size = file.file.tell()
     file.file.seek(0)  # Reset to beginning
-
+    
     if file_size > settings.max_upload_size:
         raise HTTPException(
             status_code=400,
-            detail=f"File too large. Maximum size is {settings.max_upload_size} bytes.",
+            detail=f"File too large. Maximum size is {settings.max_upload_size} bytes."
         )
-
+    
     # Create entry in database first
     entry_service = EntryService(db)
     entry = entry_service.create_entry(
@@ -73,51 +75,50 @@ async def upload_file(
         filename=file.filename,
         language=language,
     )
-
+    
     # Initialize S3 service
     s3_service = S3Service()
-
+    
     # Generate S3 key for the file
     s3_key = f"uploads/{entry.id}.{file_extension}"
-
+    
     try:
         # Upload file to S3
         success = s3_service.upload_file(
-            file.file,
+            file.file, 
             s3_key,
-            content_type=file.content_type,
+            content_type=file.content_type
         )
-
+        
         if not success:
             raise HTTPException(status_code=500, detail="Failed to upload file to S3")
-
+        
         # Update entry with S3 key as file path
         entry = entry_service.update_entry_file_path(entry.id, s3_key)
-
+        
         # Start background processing
         # TODO: Implement background task for ASR processing
-
+        
         return EntryResponse.from_orm(entry)
-
+        
     except Exception as e:
         # Clean up S3 file if database operation fails
         s3_service.delete_file(s3_key)
         raise HTTPException(status_code=500, detail=f"Failed to save file: {str(e)}")
 
-
 @router.post("/url", response_model=EntryResponse)
 async def create_from_url(
     entry_data: EntryCreate,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user),
+    current_user: bool = Depends(get_current_user)
 ):
     """Create entry from URL"""
-
+    
     if not entry_data.source_url:
         raise HTTPException(status_code=400, detail="source_url is required")
-
+    
     # TODO: Validate URL and check if it's from supported services
-
+    
     entry_service = EntryService(db)
     entry = entry_service.create_entry(
         title=entry_data.title,
@@ -125,9 +126,9 @@ async def create_from_url(
         source_url=str(entry_data.source_url),
         language=entry_data.language,
     )
-
+    
     # TODO: Start background processing for URL download and ASR
-
+    
     return EntryResponse.from_orm(entry)
 
 
@@ -135,7 +136,7 @@ async def create_from_url(
 async def create_from_transcript(
     entry_data: EntryTranscriptCreate,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user),
+    current_user: bool = Depends(get_current_user)
 ):
     """Create entry from an existing transcript"""
 
@@ -154,15 +155,14 @@ async def create_from_transcript(
 
     return EntryResponse.from_orm(entry)
 
-
 @router.get("/", response_model=EntryList)
 async def get_entries(
     page: int = 1,
     per_page: int = 12,
-    search: str | None = None,
+    search: Optional[str] = None,
     archived: bool = False,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user),
+    current_user: bool = Depends(get_current_user)
 ):
     """Get all entries with pagination and optional search"""
 
@@ -171,7 +171,7 @@ async def get_entries(
         page=page,
         per_page=per_page,
         search=search,
-        archived=archived,
+        archived=archived
     )
 
     total_pages = (total + per_page - 1) // per_page if total > 0 else 0
@@ -183,51 +183,48 @@ async def get_entries(
         per_page=per_page,
         total_pages=total_pages,
         has_next=page < total_pages,
-        has_previous=page > 1,
+        has_previous=page > 1
     )
-
 
 @router.get("/{entry_id}", response_model=EntryResponse)
 async def get_entry(
     entry_id: UUID,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user),
+    current_user: bool = Depends(get_current_user)
 ):
     """Get specific entry by ID"""
-
+    
     entry_service = EntryService(db)
     entry = entry_service.get_entry(entry_id)
-
+    
     if not entry:
         raise HTTPException(status_code=404, detail="Entry not found")
-
+    
     return EntryResponse.from_orm(entry)
-
 
 @router.put("/{entry_id}/status", response_model=EntryResponse)
 async def update_entry_status(
     entry_id: UUID,
     status_update: EntryStatusUpdate,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user),
+    current_user: bool = Depends(get_current_user)
 ):
     """Update entry status"""
-
+    
     entry_service = EntryService(db)
     entry = entry_service.update_entry_status(entry_id, status_update.status)
-
+    
     if not entry:
         raise HTTPException(status_code=404, detail="Entry not found")
-
+    
     return EntryResponse.from_orm(entry)
-
 
 @router.put("/{entry_id}/metadata", response_model=EntryResponse)
 async def update_entry_metadata(
     entry_id: UUID,
     metadata_update: EntryMetadataUpdate,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user),
+    current_user: bool = Depends(get_current_user)
 ):
     """Update title/metadata and optionally requeue the entry for retranscription."""
 
@@ -290,13 +287,12 @@ async def update_entry_metadata(
 
     return EntryResponse.from_orm(entry)
 
-
 @router.put("/{entry_id}/archive", response_model=EntryResponse)
 async def update_entry_archive(
     entry_id: UUID,
     archive_update: EntryArchiveUpdate,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user),
+    current_user: bool = Depends(get_current_user)
 ):
     """Archive or unarchive an entry"""
 
@@ -312,58 +308,66 @@ async def update_entry_archive(
 
     return EntryResponse.from_orm(entry)
 
-
 @router.delete("/{entry_id}")
 async def delete_entry(
     entry_id: UUID,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user),
+    current_user: bool = Depends(get_current_user)
 ):
     """Delete entry and associated file"""
-
+    
     entry_service = EntryService(db)
     success = entry_service.delete_entry(entry_id)
-
+    
     if not success:
         raise HTTPException(status_code=404, detail="Entry not found")
-
+    
     return {"message": "Entry deleted successfully"}
-
 
 @router.post("/{entry_id}/chat", response_model=ChatResponse)
 async def chat_with_entry(
     entry_id: UUID,
     chat_request: ChatRequest,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user),
+    current_user: bool = Depends(get_current_user)
 ):
     """Chat about an entry's transcript using Groq Llama 3.1"""
-
+    
     # Get the entry
     entry_service = EntryService(db)
     entry = entry_service.get_entry(entry_id)
-
+    
     if not entry:
         raise HTTPException(status_code=404, detail="Entry not found")
-
+    
     if not entry.transcript:
         raise HTTPException(
-            status_code=400,
-            detail="Entry must have a transcript to chat about. Please wait for processing to complete.",
+            status_code=400, 
+            detail="Entry must have a transcript to chat about. Please wait for processing to complete."
         )
-
+    
     if entry.status != EntryStatus.READY:
         raise HTTPException(
             status_code=400,
-            detail=f"Entry is not ready for chat. Current status: {entry.status.value}",
+            detail=f"Entry is not ready for chat. Current status: {entry.status.value}"
         )
-
+    
     # Initialize chat service
     try:
         chat_service = ChatService()
     except ValueError as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+    raw_prompt = SystemPromptService(db).get_prompt("chat")
+    try:
+        resolved_prompt = raw_prompt.format(
+            entry_title=entry.title,
+            transcript=entry.transcript,
+        )
+    except (KeyError, ValueError):
+        logger.warning("Failed to format chat system prompt, using raw body")
+        resolved_prompt = raw_prompt
+    
     # Convert conversation history to dict format
     conversation_history = None
     if chat_request.conversation_history:
@@ -371,24 +375,24 @@ async def chat_with_entry(
             {"role": msg.role, "content": msg.content}
             for msg in chat_request.conversation_history
         ]
-
+    
     try:
         # Generate response
         response_message = await chat_service.chat_with_entry(
             entry=entry,
             user_message=chat_request.message,
             conversation_history=conversation_history,
+            system_prompt=resolved_prompt,
         )
-
+        
         return ChatResponse(
             message=response_message,
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.utcnow()
         )
-
+        
     except Exception as e:
         logger.error(f"Chat error for entry {entry_id}: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to generate chat response")
-
 
 _RANGE_HEADER = re.compile(r"^bytes=(\d*)-(\d*)$")
 _AUDIO_STREAM_CHUNK = 64 * 1024  # 64 KiB per S3 read
@@ -406,10 +410,7 @@ async def stream_entry_audio(
     entry_service = EntryService(db)
     entry = entry_service.get_entry(entry_id)
     if not entry or not entry.file_path:
-        raise HTTPException(
-            status_code=404,
-            detail="Audio not available for this entry",
-        )
+        raise HTTPException(status_code=404, detail="Audio not available for this entry")
 
     s3_service = S3Service()
     info = s3_service.get_file_info(entry.file_path)
@@ -457,10 +458,7 @@ async def stream_entry_audio(
         s3_response = s3_service.s3_client.get_object(**kwargs)
     except Exception as exc:
         logger.error(f"Failed to fetch audio for entry {entry_id}: {exc}")
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to fetch audio from storage",
-        )
+        raise HTTPException(status_code=500, detail="Failed to fetch audio from storage")
 
     body = s3_response["Body"]
 
@@ -494,47 +492,52 @@ async def stream_entry_audio(
 async def generate_entry_summary(
     entry_id: UUID,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user),
+    current_user: bool = Depends(get_current_user)
 ):
     """Generate an AI summary of the entry's transcript"""
-
+    
     # Get the entry
     entry_service = EntryService(db)
     entry = entry_service.get_entry(entry_id)
-
+    
     if not entry:
         raise HTTPException(status_code=404, detail="Entry not found")
-
+    
     if not entry.transcript:
         raise HTTPException(
             status_code=400,
-            detail="Entry must have a transcript to summarize",
+            detail="Entry must have a transcript to summarize"
         )
-
+    
     if entry.status != EntryStatus.READY:
         raise HTTPException(
             status_code=400,
-            detail=f"Entry is not ready for summary. Current status: {entry.status.value}",
+            detail=f"Entry is not ready for summary. Current status: {entry.status.value}"
         )
-
+    
     # Initialize chat service
     try:
         chat_service = ChatService()
     except ValueError as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+    summary_system_prompt = SystemPromptService(db).get_prompt("summary")
+    
     try:
         # Generate summary
-        summary = await chat_service.generate_summary(entry)
-
+        summary = await chat_service.generate_summary(
+            entry,
+            system_prompt=summary_system_prompt,
+        )
+        
         # Update entry with summary
         entry_service.update_entry_summary(entry_id, summary)
-
+        
         return SummaryResponse(
             summary=summary,
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.utcnow()
         )
-
+        
     except Exception as e:
         logger.error(f"Summary generation error for entry {entry_id}: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to generate summary")

--- a/api/app/api/routes/entries.py
+++ b/api/app/api/routes/entries.py
@@ -358,15 +358,7 @@ async def chat_with_entry(
     except ValueError as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-    raw_prompt = SystemPromptService(db).get_prompt("chat")
-    try:
-        resolved_prompt = raw_prompt.format(
-            entry_title=entry.title,
-            transcript=entry.transcript,
-        )
-    except (KeyError, ValueError):
-        logger.warning("Failed to format chat system prompt, using raw body")
-        resolved_prompt = raw_prompt
+    resolved_prompt = SystemPromptService(db).render_prompt("chat", entry)
     
     # Convert conversation history to dict format
     conversation_history = None
@@ -521,7 +513,7 @@ async def generate_entry_summary(
     except ValueError as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-    summary_system_prompt = SystemPromptService(db).get_prompt("summary")
+    summary_system_prompt = SystemPromptService(db).render_prompt("summary", entry)
     
     try:
         # Generate summary

--- a/api/app/api/routes/entries.py
+++ b/api/app/api/routes/entries.py
@@ -1,17 +1,13 @@
-from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, File, Form, status
+from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, File, Form
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
-from typing import List, Optional
 from uuid import UUID
 from datetime import datetime
-import os
 import re
-import shutil
-from pathlib import Path
 from loguru import logger
 
 from app.db.database import get_db
-from app.models.entry import Entry, EntryStatus, SourceType
+from app.models.entry import EntryStatus, SourceType
 from app.models.schemas import (
     EntryResponse,
     EntryCreate,
@@ -34,39 +30,42 @@ from app.core.auth import get_current_user
 
 router = APIRouter()
 
+
 @router.post("/upload", response_model=EntryResponse)
 async def upload_file(
     title: str = Form(...),
     file: UploadFile = File(...),
     language: str | None = Form(default=None),
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user)
+    current_user: bool = Depends(get_current_user),
 ):
     """Upload audio or video file"""
 
     language = _normalize_language(language)
 
     # Validate file type
-    file_extension = file.filename.split('.')[-1].lower()
-    supported_formats = settings.supported_audio_formats + settings.supported_video_formats
-    
+    file_extension = file.filename.split(".")[-1].lower()
+    supported_formats = (
+        settings.supported_audio_formats + settings.supported_video_formats
+    )
+
     if file_extension not in supported_formats:
         raise HTTPException(
             status_code=400,
-            detail=f"Unsupported file format. Supported: {', '.join(supported_formats)}"
+            detail=f"Unsupported file format. Supported: {', '.join(supported_formats)}",
         )
-    
+
     # Validate file size
     file.file.seek(0, 2)  # Seek to end
     file_size = file.file.tell()
     file.file.seek(0)  # Reset to beginning
-    
+
     if file_size > settings.max_upload_size:
         raise HTTPException(
             status_code=400,
-            detail=f"File too large. Maximum size is {settings.max_upload_size} bytes."
+            detail=f"File too large. Maximum size is {settings.max_upload_size} bytes.",
         )
-    
+
     # Create entry in database first
     entry_service = EntryService(db)
     entry = entry_service.create_entry(
@@ -75,50 +74,51 @@ async def upload_file(
         filename=file.filename,
         language=language,
     )
-    
+
     # Initialize S3 service
     s3_service = S3Service()
-    
+
     # Generate S3 key for the file
     s3_key = f"uploads/{entry.id}.{file_extension}"
-    
+
     try:
         # Upload file to S3
         success = s3_service.upload_file(
-            file.file, 
+            file.file,
             s3_key,
-            content_type=file.content_type
+            content_type=file.content_type,
         )
-        
+
         if not success:
             raise HTTPException(status_code=500, detail="Failed to upload file to S3")
-        
+
         # Update entry with S3 key as file path
         entry = entry_service.update_entry_file_path(entry.id, s3_key)
-        
+
         # Start background processing
         # TODO: Implement background task for ASR processing
-        
+
         return EntryResponse.from_orm(entry)
-        
+
     except Exception as e:
         # Clean up S3 file if database operation fails
         s3_service.delete_file(s3_key)
         raise HTTPException(status_code=500, detail=f"Failed to save file: {str(e)}")
 
+
 @router.post("/url", response_model=EntryResponse)
 async def create_from_url(
     entry_data: EntryCreate,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user)
+    current_user: bool = Depends(get_current_user),
 ):
     """Create entry from URL"""
-    
+
     if not entry_data.source_url:
         raise HTTPException(status_code=400, detail="source_url is required")
-    
+
     # TODO: Validate URL and check if it's from supported services
-    
+
     entry_service = EntryService(db)
     entry = entry_service.create_entry(
         title=entry_data.title,
@@ -126,9 +126,9 @@ async def create_from_url(
         source_url=str(entry_data.source_url),
         language=entry_data.language,
     )
-    
+
     # TODO: Start background processing for URL download and ASR
-    
+
     return EntryResponse.from_orm(entry)
 
 
@@ -136,7 +136,7 @@ async def create_from_url(
 async def create_from_transcript(
     entry_data: EntryTranscriptCreate,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user)
+    current_user: bool = Depends(get_current_user),
 ):
     """Create entry from an existing transcript"""
 
@@ -155,14 +155,15 @@ async def create_from_transcript(
 
     return EntryResponse.from_orm(entry)
 
+
 @router.get("/", response_model=EntryList)
 async def get_entries(
     page: int = 1,
     per_page: int = 12,
-    search: Optional[str] = None,
+    search: str | None = None,
     archived: bool = False,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user)
+    current_user: bool = Depends(get_current_user),
 ):
     """Get all entries with pagination and optional search"""
 
@@ -171,7 +172,7 @@ async def get_entries(
         page=page,
         per_page=per_page,
         search=search,
-        archived=archived
+        archived=archived,
     )
 
     total_pages = (total + per_page - 1) // per_page if total > 0 else 0
@@ -183,48 +184,51 @@ async def get_entries(
         per_page=per_page,
         total_pages=total_pages,
         has_next=page < total_pages,
-        has_previous=page > 1
+        has_previous=page > 1,
     )
+
 
 @router.get("/{entry_id}", response_model=EntryResponse)
 async def get_entry(
     entry_id: UUID,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user)
+    current_user: bool = Depends(get_current_user),
 ):
     """Get specific entry by ID"""
-    
+
     entry_service = EntryService(db)
     entry = entry_service.get_entry(entry_id)
-    
+
     if not entry:
         raise HTTPException(status_code=404, detail="Entry not found")
-    
+
     return EntryResponse.from_orm(entry)
+
 
 @router.put("/{entry_id}/status", response_model=EntryResponse)
 async def update_entry_status(
     entry_id: UUID,
     status_update: EntryStatusUpdate,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user)
+    current_user: bool = Depends(get_current_user),
 ):
     """Update entry status"""
-    
+
     entry_service = EntryService(db)
     entry = entry_service.update_entry_status(entry_id, status_update.status)
-    
+
     if not entry:
         raise HTTPException(status_code=404, detail="Entry not found")
-    
+
     return EntryResponse.from_orm(entry)
+
 
 @router.put("/{entry_id}/metadata", response_model=EntryResponse)
 async def update_entry_metadata(
     entry_id: UUID,
     metadata_update: EntryMetadataUpdate,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user)
+    current_user: bool = Depends(get_current_user),
 ):
     """Update title/metadata and optionally requeue the entry for retranscription."""
 
@@ -287,12 +291,13 @@ async def update_entry_metadata(
 
     return EntryResponse.from_orm(entry)
 
+
 @router.put("/{entry_id}/archive", response_model=EntryResponse)
 async def update_entry_archive(
     entry_id: UUID,
     archive_update: EntryArchiveUpdate,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user)
+    current_user: bool = Depends(get_current_user),
 ):
     """Archive or unarchive an entry"""
 
@@ -308,50 +313,52 @@ async def update_entry_archive(
 
     return EntryResponse.from_orm(entry)
 
+
 @router.delete("/{entry_id}")
 async def delete_entry(
     entry_id: UUID,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user)
+    current_user: bool = Depends(get_current_user),
 ):
     """Delete entry and associated file"""
-    
+
     entry_service = EntryService(db)
     success = entry_service.delete_entry(entry_id)
-    
+
     if not success:
         raise HTTPException(status_code=404, detail="Entry not found")
-    
+
     return {"message": "Entry deleted successfully"}
+
 
 @router.post("/{entry_id}/chat", response_model=ChatResponse)
 async def chat_with_entry(
     entry_id: UUID,
     chat_request: ChatRequest,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user)
+    current_user: bool = Depends(get_current_user),
 ):
     """Chat about an entry's transcript using Groq Llama 3.1"""
-    
+
     # Get the entry
     entry_service = EntryService(db)
     entry = entry_service.get_entry(entry_id)
-    
+
     if not entry:
         raise HTTPException(status_code=404, detail="Entry not found")
-    
+
     if not entry.transcript:
         raise HTTPException(
-            status_code=400, 
-            detail="Entry must have a transcript to chat about. Please wait for processing to complete."
+            status_code=400,
+            detail="Entry must have a transcript to chat about. Please wait for processing to complete.",
         )
-    
+
     if entry.status != EntryStatus.READY:
         raise HTTPException(
             status_code=400,
-            detail=f"Entry is not ready for chat. Current status: {entry.status.value}"
+            detail=f"Entry is not ready for chat. Current status: {entry.status.value}",
         )
-    
+
     # Initialize chat service
     try:
         chat_service = ChatService()
@@ -359,7 +366,7 @@ async def chat_with_entry(
         raise HTTPException(status_code=500, detail=str(e))
 
     resolved_prompt = SystemPromptService(db).render_prompt("chat", entry)
-    
+
     # Convert conversation history to dict format
     conversation_history = None
     if chat_request.conversation_history:
@@ -367,7 +374,7 @@ async def chat_with_entry(
             {"role": msg.role, "content": msg.content}
             for msg in chat_request.conversation_history
         ]
-    
+
     try:
         # Generate response
         response_message = await chat_service.chat_with_entry(
@@ -376,15 +383,16 @@ async def chat_with_entry(
             conversation_history=conversation_history,
             system_prompt=resolved_prompt,
         )
-        
+
         return ChatResponse(
             message=response_message,
-            timestamp=datetime.utcnow()
+            timestamp=datetime.utcnow(),
         )
-        
+
     except Exception as e:
         logger.error(f"Chat error for entry {entry_id}: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to generate chat response")
+
 
 _RANGE_HEADER = re.compile(r"^bytes=(\d*)-(\d*)$")
 _AUDIO_STREAM_CHUNK = 64 * 1024  # 64 KiB per S3 read
@@ -402,7 +410,10 @@ async def stream_entry_audio(
     entry_service = EntryService(db)
     entry = entry_service.get_entry(entry_id)
     if not entry or not entry.file_path:
-        raise HTTPException(status_code=404, detail="Audio not available for this entry")
+        raise HTTPException(
+            status_code=404,
+            detail="Audio not available for this entry",
+        )
 
     s3_service = S3Service()
     info = s3_service.get_file_info(entry.file_path)
@@ -450,7 +461,10 @@ async def stream_entry_audio(
         s3_response = s3_service.s3_client.get_object(**kwargs)
     except Exception as exc:
         logger.error(f"Failed to fetch audio for entry {entry_id}: {exc}")
-        raise HTTPException(status_code=500, detail="Failed to fetch audio from storage")
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to fetch audio from storage",
+        )
 
     body = s3_response["Body"]
 
@@ -484,29 +498,29 @@ async def stream_entry_audio(
 async def generate_entry_summary(
     entry_id: UUID,
     db: Session = Depends(get_db),
-    current_user: bool = Depends(get_current_user)
+    current_user: bool = Depends(get_current_user),
 ):
     """Generate an AI summary of the entry's transcript"""
-    
+
     # Get the entry
     entry_service = EntryService(db)
     entry = entry_service.get_entry(entry_id)
-    
+
     if not entry:
         raise HTTPException(status_code=404, detail="Entry not found")
-    
+
     if not entry.transcript:
         raise HTTPException(
             status_code=400,
-            detail="Entry must have a transcript to summarize"
+            detail="Entry must have a transcript to summarize",
         )
-    
+
     if entry.status != EntryStatus.READY:
         raise HTTPException(
             status_code=400,
-            detail=f"Entry is not ready for summary. Current status: {entry.status.value}"
+            detail=f"Entry is not ready for summary. Current status: {entry.status.value}",
         )
-    
+
     # Initialize chat service
     try:
         chat_service = ChatService()
@@ -514,22 +528,22 @@ async def generate_entry_summary(
         raise HTTPException(status_code=500, detail=str(e))
 
     summary_system_prompt = SystemPromptService(db).render_prompt("summary", entry)
-    
+
     try:
         # Generate summary
         summary = await chat_service.generate_summary(
             entry,
             system_prompt=summary_system_prompt,
         )
-        
+
         # Update entry with summary
         entry_service.update_entry_summary(entry_id, summary)
-        
+
         return SummaryResponse(
             summary=summary,
-            timestamp=datetime.utcnow()
+            timestamp=datetime.utcnow(),
         )
-        
+
     except Exception as e:
         logger.error(f"Summary generation error for entry {entry_id}: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to generate summary")

--- a/api/app/api/routes/system_prompts.py
+++ b/api/app/api/routes/system_prompts.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import List
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
@@ -17,7 +16,7 @@ class SystemPromptTask(str, Enum):
     summary = "summary"
 
 
-@router.get("/", response_model=List[SystemPromptResponse])
+@router.get("/", response_model=list[SystemPromptResponse])
 async def list_system_prompts(
     db: Session = Depends(get_db),
     current_user: bool = Depends(get_current_user),

--- a/api/app/api/routes/system_prompts.py
+++ b/api/app/api/routes/system_prompts.py
@@ -1,0 +1,47 @@
+from enum import Enum
+from typing import List
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.core.auth import get_current_user
+from app.db.database import get_db
+from app.models.schemas import SystemPromptResponse, SystemPromptUpdate
+from app.services.system_prompt_service import SystemPromptService
+
+router = APIRouter()
+
+
+class SystemPromptTask(str, Enum):
+    chat = "chat"
+    summary = "summary"
+
+
+@router.get("/", response_model=List[SystemPromptResponse])
+async def list_system_prompts(
+    db: Session = Depends(get_db),
+    current_user: bool = Depends(get_current_user),
+):
+    service = SystemPromptService(db)
+    return service.list_prompts()
+
+
+@router.put("/{task}", response_model=SystemPromptResponse)
+async def update_system_prompt(
+    task: SystemPromptTask,
+    data: SystemPromptUpdate,
+    db: Session = Depends(get_db),
+    current_user: bool = Depends(get_current_user),
+):
+    service = SystemPromptService(db)
+    return service.update_prompt(task.value, data.body)
+
+
+@router.post("/{task}/reset", response_model=SystemPromptResponse)
+async def reset_system_prompt(
+    task: SystemPromptTask,
+    db: Session = Depends(get_db),
+    current_user: bool = Depends(get_current_user),
+):
+    service = SystemPromptService(db)
+    return service.reset_to_default(task.value)

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,10 +1,12 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.api.routes import entries, auth, prompt_templates
+from app.core.config import settings
+from app.api.routes import entries, auth, prompt_templates, system_prompts
 from app.db.database import engine, SessionLocal
+from app.models import entry, prompt_template, system_prompt  # Import models to register them
 from app.services.prompt_template_service import PromptTemplateService
-
+from app.services.system_prompt_service import SystemPromptService
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -12,24 +14,23 @@ async def lifespan(app: FastAPI):
     # Startup
     try:
         from app.db.database import Base, ensure_entry_schema
-
         Base.metadata.create_all(bind=engine)
         ensure_entry_schema()
         db = SessionLocal()
         try:
             PromptTemplateService(db).seed_defaults_if_empty()
+            SystemPromptService(db).seed_defaults()
         finally:
             db.close()
         print("✅ Database tables created/verified")
     except Exception as e:
         print(f"❌ Database migration failed: {str(e)}")
         raise
-
+    
     yield
-
+    
     # Shutdown (if needed)
     print("🔄 API shutting down")
-
 
 app = FastAPI(
     title="VoiceVault API",
@@ -37,7 +38,7 @@ app = FastAPI(
     version="1.0.0",
     docs_url="/docs",
     redoc_url="/redoc",
-    lifespan=lifespan,
+    lifespan=lifespan
 )
 
 app.add_middleware(
@@ -51,17 +52,12 @@ app.add_middleware(
 # Include routers
 app.include_router(auth.router, prefix="/api/auth", tags=["authentication"])
 app.include_router(entries.router, prefix="/api/entries", tags=["entries"])
-app.include_router(
-    prompt_templates.router,
-    prefix="/api/prompt-templates",
-    tags=["prompt-templates"],
-)
-
+app.include_router(prompt_templates.router, prefix="/api/prompt-templates", tags=["prompt-templates"])
+app.include_router(system_prompts.router, prefix="/api/system-prompts", tags=["system-prompts"])
 
 @app.get("/")
 async def root():
     return {"message": "VoiceVault API", "version": "1.0.0"}
-
 
 @app.get("/health")
 async def health_check():

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,12 +1,11 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.core.config import settings
 from app.api.routes import entries, auth, prompt_templates, system_prompts
 from app.db.database import engine, SessionLocal
-from app.models import entry, prompt_template, system_prompt  # Import models to register them
 from app.services.prompt_template_service import PromptTemplateService
 from app.services.system_prompt_service import SystemPromptService
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -14,6 +13,7 @@ async def lifespan(app: FastAPI):
     # Startup
     try:
         from app.db.database import Base, ensure_entry_schema
+
         Base.metadata.create_all(bind=engine)
         ensure_entry_schema()
         db = SessionLocal()
@@ -26,11 +26,12 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         print(f"❌ Database migration failed: {str(e)}")
         raise
-    
+
     yield
-    
+
     # Shutdown (if needed)
     print("🔄 API shutting down")
+
 
 app = FastAPI(
     title="VoiceVault API",
@@ -38,7 +39,7 @@ app = FastAPI(
     version="1.0.0",
     docs_url="/docs",
     redoc_url="/redoc",
-    lifespan=lifespan
+    lifespan=lifespan,
 )
 
 app.add_middleware(
@@ -52,12 +53,22 @@ app.add_middleware(
 # Include routers
 app.include_router(auth.router, prefix="/api/auth", tags=["authentication"])
 app.include_router(entries.router, prefix="/api/entries", tags=["entries"])
-app.include_router(prompt_templates.router, prefix="/api/prompt-templates", tags=["prompt-templates"])
-app.include_router(system_prompts.router, prefix="/api/system-prompts", tags=["system-prompts"])
+app.include_router(
+    prompt_templates.router,
+    prefix="/api/prompt-templates",
+    tags=["prompt-templates"],
+)
+app.include_router(
+    system_prompts.router,
+    prefix="/api/system-prompts",
+    tags=["system-prompts"],
+)
+
 
 @app.get("/")
 async def root():
     return {"message": "VoiceVault API", "version": "1.0.0"}
+
 
 @app.get("/health")
 async def health_check():

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -1,4 +1,5 @@
 from .entry import Entry, EntryStatus, SourceType
 from .prompt_template import PromptTemplate
+from .system_prompt import SystemPrompt
 
-__all__ = ["Entry", "EntryStatus", "SourceType", "PromptTemplate"]
+__all__ = ["Entry", "EntryStatus", "SourceType", "PromptTemplate", "SystemPrompt"]

--- a/api/app/models/schemas.py
+++ b/api/app/models/schemas.py
@@ -209,3 +209,16 @@ class PromptTemplateResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class SystemPromptUpdate(BaseModel):
+    body: str = Field(..., min_length=1)
+
+
+class SystemPromptResponse(BaseModel):
+    task: str
+    body: str
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/api/app/models/system_prompt.py
+++ b/api/app/models/system_prompt.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, String, Text
+
+from app.db.database import Base
+
+
+class SystemPrompt(Base):
+    __tablename__ = "system_prompts"
+
+    task = Column(String(50), primary_key=True)
+    body = Column(Text, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/api/app/services/chat_service.py
+++ b/api/app/services/chat_service.py
@@ -1,9 +1,9 @@
+from typing import List, Dict, Optional
 from groq import Groq
 from loguru import logger
 
 from app.core.config import settings, LLMProvider
 from app.models.entry import Entry
-
 
 class ChatService:
     def __init__(self):
@@ -17,51 +17,43 @@ class ChatService:
             self.client = Groq(api_key=settings.groq_api_key)
         elif self.provider == LLMProvider.CEREBRAS:
             if not settings.cerebras_api_key:
-                raise ValueError(
-                    "CEREBRAS_API_KEY is required for Cerebras LLM service",
-                )
+                raise ValueError("CEREBRAS_API_KEY is required for Cerebras LLM service")
             # Cerebras uses OpenAI-compatible API
             from openai import OpenAI
-
             self.client = OpenAI(
                 api_key=settings.cerebras_api_key,
-                base_url="https://api.cerebras.ai/v1",
+                base_url="https://api.cerebras.ai/v1"
             )
         elif self.provider == LLMProvider.OLLAMA:
             # Ollama uses OpenAI-compatible API
             from openai import OpenAI
-
             self.client = OpenAI(
                 base_url=f"{settings.ollama_base_url}/v1",
-                api_key="ollama",  # Ollama doesn't require a real API key
+                api_key="ollama"  # Ollama doesn't require a real API key
             )
             # Override model with Ollama-specific model
             if settings.ollama_model:
                 self.model = settings.ollama_model
         elif self.provider == LLMProvider.NEBIUS:
             if not settings.nebius_api_key:
-                raise ValueError(
-                    "NEBIUS_API_KEY is required for Nebius Token Factory LLM service",
-                )
+                raise ValueError("NEBIUS_API_KEY is required for Nebius Token Factory LLM service")
             # Nebius uses OpenAI-compatible API
             from openai import OpenAI
-
             self.client = OpenAI(
                 api_key=settings.nebius_api_key,
-                base_url="https://api.tokenfactory.nebius.com/v1/",
+                base_url="https://api.tokenfactory.nebius.com/v1/"
             )
         else:
             raise ValueError(f"Unsupported LLM provider: {self.provider}")
 
-        logger.info(
-            f"Chat Service initialized with provider: {self.provider}, model: {self.model}",
-        )
+        logger.info(f"Chat Service initialized with provider: {self.provider}, model: {self.model}")
 
     async def chat_with_entry(
         self,
         entry: Entry,
         user_message: str,
-        conversation_history: list[dict[str, str]] | None = None,
+        conversation_history: Optional[List[Dict[str, str]]] = None,
+        system_prompt: str = "",
     ) -> str:
         """
         Generate a chat response about an entry using Groq Llama 3.1
@@ -83,6 +75,7 @@ class ChatService:
             entry,
             user_message,
             conversation_history,
+            system_prompt,
         )
 
         try:
@@ -93,13 +86,11 @@ class ChatService:
                 max_tokens=1024,
                 temperature=0.7,
                 top_p=0.9,
-                stream=False,
+                stream=False
             )
 
             response = completion.choices[0].message.content
-            logger.info(
-                f"Generated chat response for entry {entry.id} ({len(response)} chars)",
-            )
+            logger.info(f"Generated chat response for entry {entry.id} ({len(response)} chars)")
 
             return response.strip()
 
@@ -111,55 +102,29 @@ class ChatService:
         self,
         entry: Entry,
         user_message: str,
-        conversation_history: list[dict[str, str]] | None = None,
-    ) -> list[dict[str, str]]:
-        """Build the conversation context for the Llama model"""
-
-        # System prompt with transcript context
-        metadata_section = self._format_metadata_section(entry)
-
-        system_prompt = f"""You are an AI assistant helping users analyze and discuss voice transcripts. You have access to a transcript from "{entry.title}".
-{metadata_section}
-TRANSCRIPT CONTENT:
-{entry.transcript}
-
-Your role:
-- Answer questions about the transcript content
-- Provide insights, summaries, and analysis
-- Help identify key points, action items, and important information
-- Be conversational and helpful
-- If asked about something not in the transcript, politely mention the limitation
-- Keep responses focused and relevant to the audio content
-
-Guidelines:
-- Be accurate and only reference information from the provided transcript
-- Provide specific quotes when relevant
-- Help with analysis like sentiment, key themes, action items, etc.
-- Be concise but thorough in your responses
-"""
-
+        conversation_history: Optional[List[Dict[str, str]]] = None,
+        system_prompt: str = "",
+    ) -> List[Dict[str, str]]:
+        """Build the conversation context for the LLM"""
+        system_prompt = self._with_metadata(system_prompt, entry)
         messages = [
-            {"role": "system", "content": system_prompt},
+            {"role": "system", "content": system_prompt}
         ]
 
         # Add conversation history if provided
         if conversation_history:
             for msg in conversation_history:
                 if msg.get("role") in ["user", "assistant"]:
-                    messages.append(
-                        {
-                            "role": msg["role"],
-                            "content": msg["content"],
-                        },
-                    )
+                    messages.append({
+                        "role": msg["role"],
+                        "content": msg["content"]
+                    })
 
         # Add current user message
-        messages.append(
-            {
-                "role": "user",
-                "content": user_message,
-            },
-        )
+        messages.append({
+            "role": "user",
+            "content": user_message
+        })
 
         return messages
 
@@ -185,40 +150,29 @@ Guidelines:
         sections.append("")
         return "\n".join(sections)
 
-    async def generate_summary(self, entry: Entry) -> str:
+    @classmethod
+    def _with_metadata(cls, system_prompt: str, entry: Entry) -> str:
+        metadata_section = cls._format_metadata_section(entry)
+        if not metadata_section:
+            return system_prompt
+        return f"{system_prompt}\n{metadata_section}"
+
+    async def generate_summary(self, entry: Entry, system_prompt: str = "") -> str:
         """Generate a summary of the entry transcript"""
 
         if not entry.transcript:
             raise ValueError("Entry must have a transcript to summarize")
 
-        metadata_section = self._format_metadata_section(entry)
-
-        summary_prompt = f"""Please provide a concise summary of this transcript from "{entry.title}":
-{metadata_section}
-TRANSCRIPT:
-{entry.transcript}
-
-Please provide:
-1. A brief overview of the main topic/purpose
-2. Key points discussed
-3. Any action items or next steps mentioned
-4. Overall outcome or conclusion
-
-Keep the summary clear and structured."""
-
         try:
             completion = self.client.chat.completions.create(
                 model=self.model,
                 messages=[
-                    {
-                        "role": "system",
-                        "content": "You are an expert at summarizing voice transcripts. Provide clear, structured summaries.",
-                    },
-                    {"role": "user", "content": summary_prompt},
+                    {"role": "system", "content": self._with_metadata(system_prompt, entry)},
+                    {"role": "user", "content": entry.transcript}
                 ],
                 max_tokens=512,
                 temperature=0.3,
-                top_p=0.9,
+                top_p=0.9
             )
 
             summary = completion.choices[0].message.content
@@ -237,7 +191,7 @@ Keep the summary clear and structured."""
             test_completion = self.client.chat.completions.create(
                 model=self.model,
                 messages=[{"role": "user", "content": "Hello"}],
-                max_tokens=10,
+                max_tokens=10
             )
             return bool(test_completion.choices[0].message.content)
         except Exception as e:

--- a/api/app/services/chat_service.py
+++ b/api/app/services/chat_service.py
@@ -1,9 +1,9 @@
-from typing import List, Dict, Optional
 from groq import Groq
 from loguru import logger
 
 from app.core.config import settings, LLMProvider
 from app.models.entry import Entry
+
 
 class ChatService:
     def __init__(self):
@@ -17,42 +17,51 @@ class ChatService:
             self.client = Groq(api_key=settings.groq_api_key)
         elif self.provider == LLMProvider.CEREBRAS:
             if not settings.cerebras_api_key:
-                raise ValueError("CEREBRAS_API_KEY is required for Cerebras LLM service")
+                raise ValueError(
+                    "CEREBRAS_API_KEY is required for Cerebras LLM service",
+                )
             # Cerebras uses OpenAI-compatible API
             from openai import OpenAI
+
             self.client = OpenAI(
                 api_key=settings.cerebras_api_key,
-                base_url="https://api.cerebras.ai/v1"
+                base_url="https://api.cerebras.ai/v1",
             )
         elif self.provider == LLMProvider.OLLAMA:
             # Ollama uses OpenAI-compatible API
             from openai import OpenAI
+
             self.client = OpenAI(
                 base_url=f"{settings.ollama_base_url}/v1",
-                api_key="ollama"  # Ollama doesn't require a real API key
+                api_key="ollama",  # Ollama doesn't require a real API key
             )
             # Override model with Ollama-specific model
             if settings.ollama_model:
                 self.model = settings.ollama_model
         elif self.provider == LLMProvider.NEBIUS:
             if not settings.nebius_api_key:
-                raise ValueError("NEBIUS_API_KEY is required for Nebius Token Factory LLM service")
+                raise ValueError(
+                    "NEBIUS_API_KEY is required for Nebius Token Factory LLM service",
+                )
             # Nebius uses OpenAI-compatible API
             from openai import OpenAI
+
             self.client = OpenAI(
                 api_key=settings.nebius_api_key,
-                base_url="https://api.tokenfactory.nebius.com/v1/"
+                base_url="https://api.tokenfactory.nebius.com/v1/",
             )
         else:
             raise ValueError(f"Unsupported LLM provider: {self.provider}")
 
-        logger.info(f"Chat Service initialized with provider: {self.provider}, model: {self.model}")
+        logger.info(
+            f"Chat Service initialized with provider: {self.provider}, model: {self.model}",
+        )
 
     async def chat_with_entry(
         self,
         entry: Entry,
         user_message: str,
-        conversation_history: Optional[List[Dict[str, str]]] = None,
+        conversation_history: list[dict[str, str]] | None = None,
         system_prompt: str = "",
     ) -> str:
         """
@@ -86,11 +95,13 @@ class ChatService:
                 max_tokens=1024,
                 temperature=0.7,
                 top_p=0.9,
-                stream=False
+                stream=False,
             )
 
             response = completion.choices[0].message.content
-            logger.info(f"Generated chat response for entry {entry.id} ({len(response)} chars)")
+            logger.info(
+                f"Generated chat response for entry {entry.id} ({len(response)} chars)",
+            )
 
             return response.strip()
 
@@ -102,28 +113,32 @@ class ChatService:
         self,
         entry: Entry,
         user_message: str,
-        conversation_history: Optional[List[Dict[str, str]]] = None,
+        conversation_history: list[dict[str, str]] | None = None,
         system_prompt: str = "",
-    ) -> List[Dict[str, str]]:
+    ) -> list[dict[str, str]]:
         """Build the conversation context for the LLM"""
         messages = [
-            {"role": "system", "content": system_prompt}
+            {"role": "system", "content": system_prompt},
         ]
 
         # Add conversation history if provided
         if conversation_history:
             for msg in conversation_history:
                 if msg.get("role") in ["user", "assistant"]:
-                    messages.append({
-                        "role": msg["role"],
-                        "content": msg["content"]
-                    })
+                    messages.append(
+                        {
+                            "role": msg["role"],
+                            "content": msg["content"],
+                        },
+                    )
 
         # Add current user message
-        messages.append({
-            "role": "user",
-            "content": user_message
-        })
+        messages.append(
+            {
+                "role": "user",
+                "content": user_message,
+            },
+        )
 
         return messages
 
@@ -138,11 +153,11 @@ class ChatService:
                 model=self.model,
                 messages=[
                     {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": entry.transcript}
+                    {"role": "user", "content": entry.transcript},
                 ],
                 max_tokens=512,
                 temperature=0.3,
-                top_p=0.9
+                top_p=0.9,
             )
 
             summary = completion.choices[0].message.content
@@ -161,7 +176,7 @@ class ChatService:
             test_completion = self.client.chat.completions.create(
                 model=self.model,
                 messages=[{"role": "user", "content": "Hello"}],
-                max_tokens=10
+                max_tokens=10,
             )
             return bool(test_completion.choices[0].message.content)
         except Exception as e:

--- a/api/app/services/chat_service.py
+++ b/api/app/services/chat_service.py
@@ -106,7 +106,6 @@ class ChatService:
         system_prompt: str = "",
     ) -> List[Dict[str, str]]:
         """Build the conversation context for the LLM"""
-        system_prompt = self._with_metadata(system_prompt, entry)
         messages = [
             {"role": "system", "content": system_prompt}
         ]
@@ -128,35 +127,6 @@ class ChatService:
 
         return messages
 
-    @staticmethod
-    def _format_metadata_section(entry: Entry) -> str:
-        """Render speakers and additional context as a system-prompt section.
-
-        Returns an empty string when both fields are missing/blank, so the
-        prompt stays clean for entries without metadata.
-        """
-
-        speakers = (getattr(entry, "speakers", None) or "").strip()
-        additional_context = (getattr(entry, "additional_context", None) or "").strip()
-
-        if not speakers and not additional_context:
-            return ""
-
-        sections = ["", "ENTRY METADATA:"]
-        if speakers:
-            sections.append(f"Speakers:\n{speakers}")
-        if additional_context:
-            sections.append(f"Additional Context:\n{additional_context}")
-        sections.append("")
-        return "\n".join(sections)
-
-    @classmethod
-    def _with_metadata(cls, system_prompt: str, entry: Entry) -> str:
-        metadata_section = cls._format_metadata_section(entry)
-        if not metadata_section:
-            return system_prompt
-        return f"{system_prompt}\n{metadata_section}"
-
     async def generate_summary(self, entry: Entry, system_prompt: str = "") -> str:
         """Generate a summary of the entry transcript"""
 
@@ -167,7 +137,7 @@ class ChatService:
             completion = self.client.chat.completions.create(
                 model=self.model,
                 messages=[
-                    {"role": "system", "content": self._with_metadata(system_prompt, entry)},
+                    {"role": "system", "content": system_prompt},
                     {"role": "user", "content": entry.transcript}
                 ],
                 max_tokens=512,

--- a/api/app/services/system_prompt_service.py
+++ b/api/app/services/system_prompt_service.py
@@ -7,7 +7,7 @@ from app.models.system_prompt import SystemPrompt
 
 DEFAULT_PROMPTS: dict[str, str] = {
     "chat": (
-        'You are an AI assistant helping users analyze and discuss voice transcripts.\n'
+        "You are an AI assistant helping users analyze and discuss voice transcripts.\n"
         'You have access to a transcript from "{entry_title}".\n\n'
         "Speakers: {speakers}\n"
         "Additional context: {additional_context}\n\n"
@@ -53,7 +53,7 @@ class SystemPromptService:
             )
         except (KeyError, IndexError, ValueError) as exc:
             logger.warning(
-                f"Failed to render system prompt for task={task}: {exc!r}. Using raw body."
+                f"Failed to render system prompt for task={task}: {exc!r}. Using raw body.",
             )
             return body
 
@@ -77,9 +77,13 @@ class SystemPromptService:
         inserted = 0
 
         for task, body in DEFAULT_PROMPTS.items():
-            existing = self.db.query(SystemPrompt).filter(SystemPrompt.task == task).first()
+            existing = (
+                self.db.query(SystemPrompt).filter(SystemPrompt.task == task).first()
+            )
             if existing is None:
-                self.db.add(SystemPrompt(task=task, body=body, updated_at=datetime.utcnow()))
+                self.db.add(
+                    SystemPrompt(task=task, body=body, updated_at=datetime.utcnow()),
+                )
                 inserted += 1
 
         if inserted:

--- a/api/app/services/system_prompt_service.py
+++ b/api/app/services/system_prompt_service.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from loguru import logger
 from sqlalchemy.orm import Session
 
 from app.models.system_prompt import SystemPrompt
@@ -38,6 +39,21 @@ class SystemPromptService:
         if row:
             return row.body
         return DEFAULT_PROMPTS.get(task, "")
+
+    def render_prompt(self, task: str, entry) -> str:
+        body = self.get_prompt(task)
+        try:
+            return body.format(
+                entry_title=(entry.title or ""),
+                transcript=(entry.transcript or ""),
+                speakers=(entry.speakers or "").strip(),
+                additional_context=(entry.additional_context or "").strip(),
+            )
+        except (KeyError, IndexError, ValueError) as exc:
+            logger.warning(
+                f"Failed to render system prompt for task={task}: {exc!r}. Using raw body."
+            )
+            return body
 
     def update_prompt(self, task: str, body: str) -> SystemPrompt:
         row = self.db.query(SystemPrompt).filter(SystemPrompt.task == task).first()

--- a/api/app/services/system_prompt_service.py
+++ b/api/app/services/system_prompt_service.py
@@ -9,6 +9,8 @@ DEFAULT_PROMPTS: dict[str, str] = {
     "chat": (
         'You are an AI assistant helping users analyze and discuss voice transcripts.\n'
         'You have access to a transcript from "{entry_title}".\n\n'
+        "Speakers: {speakers}\n"
+        "Additional context: {additional_context}\n\n"
         "TRANSCRIPT:\n"
         "{transcript}\n\n"
         "Guidelines:\n"

--- a/api/app/services/system_prompt_service.py
+++ b/api/app/services/system_prompt_service.py
@@ -1,0 +1,73 @@
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from app.models.system_prompt import SystemPrompt
+
+DEFAULT_PROMPTS: dict[str, str] = {
+    "chat": (
+        'You are an AI assistant helping users analyze and discuss voice transcripts.\n'
+        'You have access to a transcript from "{entry_title}".\n\n'
+        "TRANSCRIPT:\n"
+        "{transcript}\n\n"
+        "Guidelines:\n"
+        "- Answer questions accurately using only the transcript content\n"
+        "- Provide specific quotes when relevant\n"
+        "- Help with analysis: key themes, action items, decisions, sentiment\n"
+        "- If asked about something not in the transcript, say so clearly\n"
+        "- Be concise but thorough"
+    ),
+    "summary": (
+        "You are an expert analyst summarizing voice transcripts.\n"
+        "Produce a structured summary with these sections:\n\n"
+        "**Key Points** - the 3-5 most important topics discussed\n"
+        "**Decisions Made** - concrete decisions or conclusions reached\n"
+        "**Action Items** - tasks, owners, and deadlines if mentioned\n"
+        "**Open Questions** - unresolved issues or topics needing follow-up\n\n"
+        "Be factual. Only include sections where content exists in the transcript."
+    ),
+}
+
+
+class SystemPromptService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get_prompt(self, task: str) -> str:
+        row = self.db.query(SystemPrompt).filter(SystemPrompt.task == task).first()
+        if row:
+            return row.body
+        return DEFAULT_PROMPTS.get(task, "")
+
+    def update_prompt(self, task: str, body: str) -> SystemPrompt:
+        row = self.db.query(SystemPrompt).filter(SystemPrompt.task == task).first()
+        if row:
+            row.body = body
+            row.updated_at = datetime.utcnow()
+        else:
+            row = SystemPrompt(task=task, body=body, updated_at=datetime.utcnow())
+            self.db.add(row)
+
+        self.db.commit()
+        self.db.refresh(row)
+        return row
+
+    def reset_to_default(self, task: str) -> SystemPrompt:
+        return self.update_prompt(task, DEFAULT_PROMPTS[task])
+
+    def seed_defaults(self) -> int:
+        inserted = 0
+
+        for task, body in DEFAULT_PROMPTS.items():
+            existing = self.db.query(SystemPrompt).filter(SystemPrompt.task == task).first()
+            if existing is None:
+                self.db.add(SystemPrompt(task=task, body=body, updated_at=datetime.utcnow()))
+                inserted += 1
+
+        if inserted:
+            self.db.commit()
+
+        return inserted
+
+    def list_prompts(self) -> list[SystemPrompt]:
+        return self.db.query(SystemPrompt).all()

--- a/api/tests/test_system_prompt_service.py
+++ b/api/tests/test_system_prompt_service.py
@@ -24,8 +24,13 @@ class SystemPromptServiceTests(TestCase):
     def make_row(self, task="chat", body="custom body"):
         return SimpleNamespace(task=task, body=body)
 
-    def make_entry(self, title="Demo entry", transcript="Hello world",
-                   speakers="Alice, Bob", additional_context="Standup notes"):
+    def make_entry(
+        self,
+        title="Demo entry",
+        transcript="Hello world",
+        speakers="Alice, Bob",
+        additional_context="Standup notes",
+    ):
         return SimpleNamespace(
             title=title,
             transcript=transcript,
@@ -37,7 +42,8 @@ class SystemPromptServiceTests(TestCase):
         db = MagicMock()
         service = SystemPromptService(db)
         db.query.return_value.filter.return_value.first.return_value = self.make_row(
-            task="chat", body="db body"
+            task="chat",
+            body="db body",
         )
 
         result = service.get_prompt("chat")
@@ -137,8 +143,10 @@ class SystemPromptServiceTests(TestCase):
         service = SystemPromptService(db)
         db.query.return_value.filter.return_value.first.return_value = self.make_row(
             task="chat",
-            body=("Title: {entry_title}\nSpeakers: {speakers}\n"
-                  "Context: {additional_context}\nTranscript: {transcript}"),
+            body=(
+                "Title: {entry_title}\nSpeakers: {speakers}\n"
+                "Context: {additional_context}\nTranscript: {transcript}"
+            ),
         )
 
         result = service.render_prompt("chat", self.make_entry())

--- a/api/tests/test_system_prompt_service.py
+++ b/api/tests/test_system_prompt_service.py
@@ -24,6 +24,15 @@ class SystemPromptServiceTests(TestCase):
     def make_row(self, task="chat", body="custom body"):
         return SimpleNamespace(task=task, body=body)
 
+    def make_entry(self, title="Demo entry", transcript="Hello world",
+                   speakers="Alice, Bob", additional_context="Standup notes"):
+        return SimpleNamespace(
+            title=title,
+            transcript=transcript,
+            speakers=speakers,
+            additional_context=additional_context,
+        )
+
     def test_get_prompt_returns_db_body_when_row_exists(self):
         db = MagicMock()
         service = SystemPromptService(db)
@@ -117,3 +126,100 @@ class SystemPromptServiceTests(TestCase):
         self.assertIn("summary", DEFAULT_PROMPTS)
         self.assertIn("{entry_title}", DEFAULT_PROMPTS["chat"])
         self.assertIn("{transcript}", DEFAULT_PROMPTS["chat"])
+
+    def test_render_prompt_substitutes_all_four_placeholders(self):
+        db = MagicMock()
+        service = SystemPromptService(db)
+        db.query.return_value.filter.return_value.first.return_value = self.make_row(
+            task="chat",
+            body=("Title: {entry_title}\nSpeakers: {speakers}\n"
+                  "Context: {additional_context}\nTranscript: {transcript}"),
+        )
+
+        result = service.render_prompt("chat", self.make_entry())
+
+        self.assertEqual(
+            result,
+            "Title: Demo entry\nSpeakers: Alice, Bob\n"
+            "Context: Standup notes\nTranscript: Hello world",
+        )
+
+    def test_render_prompt_substitutes_empty_strings_for_missing_metadata(self):
+        db = MagicMock()
+        service = SystemPromptService(db)
+        db.query.return_value.filter.return_value.first.return_value = self.make_row(
+            task="chat",
+            body="Speakers: {speakers}\nContext: {additional_context}",
+        )
+
+        result = service.render_prompt(
+            "chat",
+            self.make_entry(speakers="", additional_context=None),
+        )
+
+        self.assertEqual(result, "Speakers: \nContext: ")
+
+    def test_render_prompt_strips_whitespace_from_metadata(self):
+        db = MagicMock()
+        service = SystemPromptService(db)
+        db.query.return_value.filter.return_value.first.return_value = self.make_row(
+            task="chat",
+            body="Speakers: {speakers}",
+        )
+
+        result = service.render_prompt(
+            "chat",
+            self.make_entry(speakers="  Alice  \n"),
+        )
+
+        self.assertEqual(result, "Speakers: Alice")
+
+    def test_render_prompt_falls_back_to_raw_body_on_unknown_placeholder(self):
+        db = MagicMock()
+        service = SystemPromptService(db)
+        raw_body = "Hello {foo}"
+        db.query.return_value.filter.return_value.first.return_value = self.make_row(
+            task="chat",
+            body=raw_body,
+        )
+
+        result = service.render_prompt("chat", self.make_entry())
+
+        self.assertEqual(result, raw_body)
+
+    def test_render_prompt_falls_back_to_raw_body_on_malformed_template(self):
+        db = MagicMock()
+        service = SystemPromptService(db)
+        raw_body = "Unbalanced {entry_title"
+        db.query.return_value.filter.return_value.first.return_value = self.make_row(
+            task="chat",
+            body=raw_body,
+        )
+
+        result = service.render_prompt("chat", self.make_entry())
+
+        self.assertEqual(result, raw_body)
+
+    def test_render_prompt_returns_empty_string_when_body_is_empty(self):
+        db = MagicMock()
+        service = SystemPromptService(db)
+        db.query.return_value.filter.return_value.first.return_value = self.make_row(
+            task="chat",
+            body="",
+        )
+
+        result = service.render_prompt("chat", self.make_entry())
+
+        self.assertEqual(result, "")
+
+    def test_render_prompt_works_for_summary_task(self):
+        db = MagicMock()
+        service = SystemPromptService(db)
+        db.query.return_value.filter.return_value.first.return_value = self.make_row(
+            task="summary",
+            body="Summarize {entry_title}: {transcript}",
+        )
+
+        result = service.render_prompt("summary", self.make_entry())
+
+        self.assertEqual(result, "Summarize Demo entry: Hello world")

--- a/api/tests/test_system_prompt_service.py
+++ b/api/tests/test_system_prompt_service.py
@@ -124,8 +124,13 @@ class SystemPromptServiceTests(TestCase):
     def test_default_prompts_has_chat_and_summary_keys(self):
         self.assertIn("chat", DEFAULT_PROMPTS)
         self.assertIn("summary", DEFAULT_PROMPTS)
-        self.assertIn("{entry_title}", DEFAULT_PROMPTS["chat"])
-        self.assertIn("{transcript}", DEFAULT_PROMPTS["chat"])
+
+    def test_default_chat_prompt_uses_all_four_placeholders(self):
+        chat_default = DEFAULT_PROMPTS["chat"]
+        self.assertIn("{entry_title}", chat_default)
+        self.assertIn("{transcript}", chat_default)
+        self.assertIn("{speakers}", chat_default)
+        self.assertIn("{additional_context}", chat_default)
 
     def test_render_prompt_substitutes_all_four_placeholders(self):
         db = MagicMock()

--- a/api/tests/test_system_prompt_service.py
+++ b/api/tests/test_system_prompt_service.py
@@ -1,0 +1,119 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.models.system_prompt import SystemPrompt
+from app.services.system_prompt_service import DEFAULT_PROMPTS, SystemPromptService
+
+
+class SystemPromptModelTests(TestCase):
+    def test_model_has_expected_columns(self):
+        cols = {c.name for c in SystemPrompt.__table__.columns}
+        self.assertEqual(cols, {"task", "body", "updated_at"})
+
+    def test_task_is_primary_key(self):
+        pk_cols = {c.name for c in SystemPrompt.__table__.primary_key.columns}
+        self.assertEqual(pk_cols, {"task"})
+
+
+class SystemPromptServiceTests(TestCase):
+    def make_row(self, task="chat", body="custom body"):
+        return SimpleNamespace(task=task, body=body)
+
+    def test_get_prompt_returns_db_body_when_row_exists(self):
+        db = MagicMock()
+        service = SystemPromptService(db)
+        db.query.return_value.filter.return_value.first.return_value = self.make_row(
+            task="chat", body="db body"
+        )
+
+        result = service.get_prompt("chat")
+
+        self.assertEqual(result, "db body")
+
+    def test_get_prompt_falls_back_to_default_when_row_missing(self):
+        db = MagicMock()
+        service = SystemPromptService(db)
+        db.query.return_value.filter.return_value.first.return_value = None
+
+        result = service.get_prompt("chat")
+
+        self.assertEqual(result, DEFAULT_PROMPTS["chat"])
+
+    def test_update_prompt_updates_existing_row(self):
+        db = MagicMock()
+        service = SystemPromptService(db)
+        existing = self.make_row(task="chat", body="old body")
+        db.query.return_value.filter.return_value.first.return_value = existing
+
+        service.update_prompt("chat", "new body")
+
+        self.assertEqual(existing.body, "new body")
+        db.commit.assert_called_once()
+
+    def test_update_prompt_inserts_when_row_missing(self):
+        db = MagicMock()
+        service = SystemPromptService(db)
+        db.query.return_value.filter.return_value.first.return_value = None
+
+        service.update_prompt("chat", "new body")
+
+        db.add.assert_called_once()
+        db.commit.assert_called_once()
+
+    def test_reset_to_default_restores_default_body(self):
+        db = MagicMock()
+        service = SystemPromptService(db)
+        existing = self.make_row(task="summary", body="custom")
+        db.query.return_value.filter.return_value.first.return_value = existing
+
+        service.reset_to_default("summary")
+
+        self.assertEqual(existing.body, DEFAULT_PROMPTS["summary"])
+
+    def test_seed_defaults_inserts_when_row_missing(self):
+        db = MagicMock()
+        service = SystemPromptService(db)
+        db.query.return_value.filter.return_value.first.return_value = None
+
+        service.seed_defaults()
+
+        self.assertEqual(db.add.call_count, len(DEFAULT_PROMPTS))
+        db.commit.assert_called_once()
+
+    def test_seed_defaults_preserves_existing_rows(self):
+        db = MagicMock()
+        service = SystemPromptService(db)
+        existing_chat = self.make_row(task="chat", body="custom body")
+        existing_summary = self.make_row(task="summary", body="custom summary")
+        db.query.return_value.filter.return_value.first.side_effect = [
+            existing_chat,
+            existing_summary,
+        ]
+
+        service.seed_defaults()
+
+        self.assertEqual(existing_chat.body, "custom body")
+        self.assertEqual(existing_summary.body, "custom summary")
+        db.add.assert_not_called()
+        db.commit.assert_not_called()
+
+    def test_list_prompts_returns_all_rows(self):
+        db = MagicMock()
+        service = SystemPromptService(db)
+        rows = [self.make_row("chat"), self.make_row("summary")]
+        db.query.return_value.all.return_value = rows
+
+        result = service.list_prompts()
+
+        self.assertEqual(result, rows)
+
+    def test_default_prompts_has_chat_and_summary_keys(self):
+        self.assertIn("chat", DEFAULT_PROMPTS)
+        self.assertIn("summary", DEFAULT_PROMPTS)
+        self.assertIn("{entry_title}", DEFAULT_PROMPTS["chat"])
+        self.assertIn("{transcript}", DEFAULT_PROMPTS["chat"])

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -7,10 +7,10 @@ import { ChatInterface } from './components/ChatInterface';
 import { EntryMetadataModal } from './components/EntryMetadataModal';
 import { TranscriptTimestampModal } from './components/TranscriptTimestampModal';
 import { Login } from './components/Login';
-import { PromptTemplateManager } from './components/PromptTemplateManager';
+import { SettingsModal } from './components/SettingsModal';
 import { SearchBar } from './components/SearchBar';
 import { entryApi, auth } from './services/api';
-import { Entry, PromptTemplate, PromptTemplateCreate, PromptTemplateUpdate } from './types';
+import { Entry, PromptTemplate, PromptTemplateCreate, PromptTemplateUpdate, SystemPrompt } from './types';
 import 'highlight.js/styles/github.css';
 
 type EntryFilter = 'active' | 'archived';
@@ -21,6 +21,9 @@ function App() {
   const [promptTemplates, setPromptTemplates] = useState<PromptTemplate[]>([]);
   const [promptTemplatesLoading, setPromptTemplatesLoading] = useState(false);
   const [promptTemplatesError, setPromptTemplatesError] = useState<string | null>(null);
+  const [systemPrompts, setSystemPrompts] = useState<SystemPrompt[]>([]);
+  const [systemPromptsLoading, setSystemPromptsLoading] = useState(false);
+  const [systemPromptsError, setSystemPromptsError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [selectedEntry, setSelectedEntry] = useState<Entry | null>(null);
   const [page, setPage] = useState(1);
@@ -86,6 +89,21 @@ function App() {
     }
   }, [sortPromptTemplates]);
 
+  const fetchSystemPrompts = useCallback(async () => {
+    setSystemPromptsLoading(true);
+    setSystemPromptsError(null);
+
+    try {
+      const prompts = await entryApi.getSystemPrompts();
+      setSystemPrompts(prompts);
+    } catch (error) {
+      console.error('Failed to fetch system prompts:', error);
+      setSystemPromptsError('Failed to load system prompts');
+    } finally {
+      setSystemPromptsLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     if (auth.isAuthenticated()) {
       setIsAuthenticated(true);
@@ -108,6 +126,12 @@ function App() {
       fetchPromptTemplates();
     }
   }, [isAuthenticated, fetchPromptTemplates]);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      fetchSystemPrompts();
+    }
+  }, [isAuthenticated, fetchSystemPrompts]);
 
   useEffect(() => {
     if (isAuthenticated && autoRefreshEnabled && page === 1 && !searchQuery && !isArchivedView) {
@@ -145,6 +169,8 @@ function App() {
     setEntries([]);
     setPromptTemplates([]);
     setPromptTemplatesError(null);
+    setSystemPrompts([]);
+    setSystemPromptsError(null);
     setSelectedEntry(null);
     setPage(1);
     setSearchQuery('');
@@ -242,6 +268,20 @@ function App() {
   const handleDeletePromptTemplate = async (id: string) => {
     await entryApi.deletePromptTemplate(id);
     setPromptTemplates((prev) => prev.filter((template) => template.id !== id));
+  };
+
+  const handleUpdateSystemPrompt = async (task: string, body: string) => {
+    const updated = await entryApi.updateSystemPrompt(task, body);
+    setSystemPrompts(prev => prev.map(prompt => (
+      prompt.task === task ? updated : prompt
+    )));
+  };
+
+  const handleResetSystemPrompt = async (task: string) => {
+    const updated = await entryApi.resetSystemPrompt(task);
+    setSystemPrompts(prev => prev.map(prompt => (
+      prompt.task === task ? updated : prompt
+    )));
   };
 
   const hasMore = entries.length < total;
@@ -376,13 +416,13 @@ function App() {
           left: 'max(1rem, env(safe-area-inset-left))',
           bottom: 'max(1rem, env(safe-area-inset-bottom))',
         }}
-        aria-label="Open prompt template settings"
+        aria-label="Open settings"
       >
         <Settings className="h-4 w-4" />
-        <span>Templates</span>
+        <span>Settings</span>
       </button>
 
-      <PromptTemplateManager
+      <SettingsModal
         templates={promptTemplates}
         isOpen={isTemplateManagerOpen}
         isLoading={promptTemplatesLoading}
@@ -391,6 +431,11 @@ function App() {
         onCreate={handleCreatePromptTemplate}
         onUpdate={handleUpdatePromptTemplate}
         onDelete={handleDeletePromptTemplate}
+        systemPrompts={systemPrompts}
+        systemPromptsLoading={systemPromptsLoading}
+        systemPromptsError={systemPromptsError}
+        onUpdateSystemPrompt={handleUpdateSystemPrompt}
+        onResetSystemPrompt={handleResetSystemPrompt}
       />
     </div>
   );

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,7 +10,13 @@ import { Login } from './components/Login';
 import { SettingsModal } from './components/SettingsModal';
 import { SearchBar } from './components/SearchBar';
 import { entryApi, auth } from './services/api';
-import { Entry, PromptTemplate, PromptTemplateCreate, PromptTemplateUpdate, SystemPrompt } from './types';
+import {
+  Entry,
+  PromptTemplate,
+  PromptTemplateCreate,
+  PromptTemplateUpdate,
+  SystemPrompt,
+} from './types';
 import 'highlight.js/styles/github.css';
 
 type EntryFilter = 'active' | 'archived';
@@ -272,16 +278,12 @@ function App() {
 
   const handleUpdateSystemPrompt = async (task: string, body: string) => {
     const updated = await entryApi.updateSystemPrompt(task, body);
-    setSystemPrompts(prev => prev.map(prompt => (
-      prompt.task === task ? updated : prompt
-    )));
+    setSystemPrompts((prev) => prev.map((prompt) => (prompt.task === task ? updated : prompt)));
   };
 
   const handleResetSystemPrompt = async (task: string) => {
     const updated = await entryApi.resetSystemPrompt(task);
-    setSystemPrompts(prev => prev.map(prompt => (
-      prompt.task === task ? updated : prompt
-    )));
+    setSystemPrompts((prev) => prev.map((prompt) => (prompt.task === task ? updated : prompt)));
   };
 
   const hasMore = entries.length < total;

--- a/ui/src/components/PromptTemplateManager.tsx
+++ b/ui/src/components/PromptTemplateManager.tsx
@@ -14,6 +14,7 @@ interface PromptTemplateManagerProps {
   onCreate: (template: PromptTemplateCreate) => Promise<void> | void;
   onUpdate: (id: string, template: PromptTemplateUpdate) => Promise<void> | void;
   onDelete: (id: string) => Promise<void> | void;
+  embedded?: boolean;
 }
 
 interface TemplateFormState {
@@ -50,6 +51,7 @@ export const PromptTemplateManager: React.FC<PromptTemplateManagerProps> = ({
   onCreate,
   onUpdate,
   onDelete,
+  embedded = false,
 }) => {
   const [editingTemplateId, setEditingTemplateId] = useState<string | null>(null);
   const [formState, setFormState] = useState<TemplateFormState>(() => createEmptyForm(templates));
@@ -179,8 +181,8 @@ export const PromptTemplateManager: React.FC<PromptTemplateManagerProps> = ({
 
   return (
     <>
-      <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/50 p-4">
-        <div className="flex h-[85vh] w-full max-w-6xl flex-col overflow-hidden rounded-2xl bg-white shadow-2xl md:flex-row">
+      <div className={embedded ? 'flex h-full flex-col' : 'fixed inset-0 z-40 flex items-center justify-center bg-black/50 p-4'}>
+        <div className={embedded ? 'flex flex-1 flex-col overflow-hidden md:flex-row' : 'flex h-[85vh] w-full max-w-6xl flex-col overflow-hidden rounded-2xl bg-white shadow-2xl md:flex-row'}>
           <div className="flex w-full flex-col border-b border-gray-200 md:w-[360px] md:border-b-0 md:border-r">
             <div className="flex items-center justify-between px-5 py-4">
               <div className="flex items-center gap-3">
@@ -192,13 +194,15 @@ export const PromptTemplateManager: React.FC<PromptTemplateManagerProps> = ({
                   <p className="text-sm text-gray-500">Global templates for chat starters</p>
                 </div>
               </div>
-              <button
-                onClick={onClose}
-                className="rounded-md p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
-                aria-label="Close prompt templates"
-              >
-                <X className="h-5 w-5" />
-              </button>
+              {!embedded && (
+                <button
+                  onClick={onClose}
+                  className="rounded-md p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                  aria-label="Close prompt templates"
+                >
+                  <X className="h-5 w-5" />
+                </button>
+              )}
             </div>
 
             <div className="border-y border-gray-100 px-5 py-3">

--- a/ui/src/components/PromptTemplateManager.tsx
+++ b/ui/src/components/PromptTemplateManager.tsx
@@ -181,8 +181,20 @@ export const PromptTemplateManager: React.FC<PromptTemplateManagerProps> = ({
 
   return (
     <>
-      <div className={embedded ? 'flex h-full flex-col' : 'fixed inset-0 z-40 flex items-center justify-center bg-black/50 p-4'}>
-        <div className={embedded ? 'flex flex-1 flex-col overflow-hidden md:flex-row' : 'flex h-[85vh] w-full max-w-6xl flex-col overflow-hidden rounded-2xl bg-white shadow-2xl md:flex-row'}>
+      <div
+        className={
+          embedded
+            ? 'flex h-full flex-col'
+            : 'fixed inset-0 z-40 flex items-center justify-center bg-black/50 p-4'
+        }
+      >
+        <div
+          className={
+            embedded
+              ? 'flex flex-1 flex-col overflow-hidden md:flex-row'
+              : 'flex h-[85vh] w-full max-w-6xl flex-col overflow-hidden rounded-2xl bg-white shadow-2xl md:flex-row'
+          }
+        >
           <div className="flex w-full flex-col border-b border-gray-200 md:w-[360px] md:border-b-0 md:border-r">
             <div className="flex items-center justify-between px-5 py-4">
               <div className="flex items-center gap-3">

--- a/ui/src/components/SettingsModal.test.tsx
+++ b/ui/src/components/SettingsModal.test.tsx
@@ -1,11 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { PromptTemplateManager } from './PromptTemplateManager';
+import { SettingsModal } from './SettingsModal';
 
-describe('PromptTemplateManager', () => {
+describe('SettingsModal', () => {
   it('renders templates and opens the add form', () => {
     render(
-      <PromptTemplateManager
+      <SettingsModal
         templates={[
           {
             id: 'template-1',
@@ -25,7 +25,12 @@ describe('PromptTemplateManager', () => {
         onCreate={vi.fn()}
         onUpdate={vi.fn()}
         onDelete={vi.fn()}
-      />,
+        systemPrompts={[]}
+        systemPromptsLoading={false}
+        systemPromptsError={null}
+        onUpdateSystemPrompt={vi.fn()}
+        onResetSystemPrompt={vi.fn()}
+      />
     );
 
     expect(screen.getByText('Action items')).toBeInTheDocument();

--- a/ui/src/components/SettingsModal.test.tsx
+++ b/ui/src/components/SettingsModal.test.tsx
@@ -30,7 +30,7 @@ describe('SettingsModal', () => {
         systemPromptsError={null}
         onUpdateSystemPrompt={vi.fn()}
         onResetSystemPrompt={vi.fn()}
-      />
+      />,
     );
 
     expect(screen.getByText('Action items')).toBeInTheDocument();

--- a/ui/src/components/SettingsModal.tsx
+++ b/ui/src/components/SettingsModal.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import { X } from 'lucide-react';
+
+import { PromptTemplate, PromptTemplateCreate, PromptTemplateUpdate, SystemPrompt } from '../types';
+import { PromptTemplateManager } from './PromptTemplateManager';
+import { SystemPromptSettings } from './SystemPromptSettings';
+
+type Tab = 'templates' | 'system-prompts';
+
+interface SettingsModalProps {
+  templates: PromptTemplate[];
+  isOpen: boolean;
+  isLoading: boolean;
+  error: string | null;
+  onClose: () => void;
+  onCreate: (template: PromptTemplateCreate) => Promise<void> | void;
+  onUpdate: (id: string, template: PromptTemplateUpdate) => Promise<void> | void;
+  onDelete: (id: string) => Promise<void> | void;
+  systemPrompts: SystemPrompt[];
+  systemPromptsLoading: boolean;
+  systemPromptsError: string | null;
+  onUpdateSystemPrompt: (task: string, body: string) => Promise<void>;
+  onResetSystemPrompt: (task: string) => Promise<void>;
+}
+
+export const SettingsModal: React.FC<SettingsModalProps> = ({
+  templates,
+  isOpen,
+  isLoading,
+  error,
+  onClose,
+  onCreate,
+  onUpdate,
+  onDelete,
+  systemPrompts,
+  systemPromptsLoading,
+  systemPromptsError,
+  onUpdateSystemPrompt,
+  onResetSystemPrompt,
+}) => {
+  const [activeTab, setActiveTab] = useState<Tab>('templates');
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="relative flex h-[85vh] w-full max-w-6xl flex-col overflow-hidden rounded-2xl bg-white shadow-2xl">
+        <div className="flex items-center justify-between border-b border-gray-200 px-6 py-4">
+          <h2 className="text-lg font-semibold text-gray-900">Settings</h2>
+          <button
+            onClick={onClose}
+            className="rounded-md p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+            aria-label="Close settings"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="flex border-b border-gray-200 px-6">
+          <button
+            className={`mr-4 border-b-2 py-3 text-sm font-medium transition-colors ${
+              activeTab === 'templates'
+                ? 'border-blue-600 text-blue-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700'
+            }`}
+            onClick={() => setActiveTab('templates')}
+          >
+            Templates
+          </button>
+          <button
+            className={`border-b-2 py-3 text-sm font-medium transition-colors ${
+              activeTab === 'system-prompts'
+                ? 'border-blue-600 text-blue-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700'
+            }`}
+            onClick={() => setActiveTab('system-prompts')}
+          >
+            System Prompts
+          </button>
+        </div>
+
+        <div className={`flex-1 overflow-auto ${activeTab === 'templates' ? '' : 'hidden'}`}>
+          <PromptTemplateManager
+            embedded
+            templates={templates}
+            isOpen={isOpen}
+            isLoading={isLoading}
+            error={error}
+            onClose={onClose}
+            onCreate={onCreate}
+            onUpdate={onUpdate}
+            onDelete={onDelete}
+          />
+        </div>
+        <div className={`flex-1 overflow-auto ${activeTab === 'system-prompts' ? '' : 'hidden'}`}>
+          <SystemPromptSettings
+            prompts={systemPrompts}
+            isLoading={systemPromptsLoading}
+            error={systemPromptsError}
+            onUpdate={onUpdateSystemPrompt}
+            onReset={onResetSystemPrompt}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/ui/src/components/SystemPromptSettings.test.tsx
+++ b/ui/src/components/SystemPromptSettings.test.tsx
@@ -131,4 +131,54 @@ describe('SystemPromptSettings', () => {
 
     expect(onReset).not.toHaveBeenCalled();
   });
+
+  it('renders an Available variables details block per card', () => {
+    render(
+      <SystemPromptSettings
+        prompts={mockPrompts}
+        isLoading={false}
+        error={null}
+        onUpdate={vi.fn()}
+        onReset={vi.fn()}
+      />
+    );
+
+    const details = screen.getAllByText('Available variables');
+    expect(details).toHaveLength(2);
+  });
+
+  it('lists all four variable names in each details block', () => {
+    render(
+      <SystemPromptSettings
+        prompts={mockPrompts}
+        isLoading={false}
+        error={null}
+        onUpdate={vi.fn()}
+        onReset={vi.fn()}
+      />
+    );
+
+    for (const name of ['{entry_title}', '{transcript}', '{speakers}', '{additional_context}']) {
+      const matches = screen.getAllByText(name);
+      expect(matches.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it('keeps Available variables collapsed by default', () => {
+    const { container } = render(
+      <SystemPromptSettings
+        prompts={mockPrompts}
+        isLoading={false}
+        error={null}
+        onUpdate={vi.fn()}
+        onReset={vi.fn()}
+      />
+    );
+
+    const detailsElements = container.querySelectorAll('details');
+    expect(detailsElements.length).toBe(2);
+    for (const el of detailsElements) {
+      expect(el.hasAttribute('open')).toBe(false);
+    }
+  });
 });

--- a/ui/src/components/SystemPromptSettings.test.tsx
+++ b/ui/src/components/SystemPromptSettings.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SystemPromptSettings } from './SystemPromptSettings';
+
+const mockPrompts = [
+  {
+    task: 'chat' as const,
+    body: 'You are a chat assistant.',
+    updated_at: '2026-04-09T00:00:00Z',
+  },
+  {
+    task: 'summary' as const,
+    body: 'You are a summary assistant.',
+    updated_at: '2026-04-09T00:00:00Z',
+  },
+];
+
+describe('SystemPromptSettings', () => {
+  it('renders both task cards', () => {
+    render(
+      <SystemPromptSettings
+        prompts={mockPrompts}
+        isLoading={false}
+        error={null}
+        onUpdate={vi.fn()}
+        onReset={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Chat')).toBeInTheDocument();
+    expect(screen.getByText('Summary')).toBeInTheDocument();
+  });
+
+  it('shows current body in each textarea', () => {
+    render(
+      <SystemPromptSettings
+        prompts={mockPrompts}
+        isLoading={false}
+        error={null}
+        onUpdate={vi.fn()}
+        onReset={vi.fn()}
+      />
+    );
+
+    const textareas = screen.getAllByRole('textbox');
+    expect(textareas[0]).toHaveValue('You are a chat assistant.');
+    expect(textareas[1]).toHaveValue('You are a summary assistant.');
+  });
+
+  it('marks card dirty when body is edited', () => {
+    render(
+      <SystemPromptSettings
+        prompts={mockPrompts}
+        isLoading={false}
+        error={null}
+        onUpdate={vi.fn()}
+        onReset={vi.fn()}
+      />
+    );
+
+    const textareas = screen.getAllByRole('textbox');
+    fireEvent.change(textareas[0], { target: { value: 'edited chat prompt' } });
+
+    const saveButtons = screen.getAllByRole('button', { name: /save/i });
+    expect(saveButtons[0]).not.toBeDisabled();
+  });
+
+  it('calls onUpdate with task and new body when Save is clicked', async () => {
+    const onUpdate = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <SystemPromptSettings
+        prompts={mockPrompts}
+        isLoading={false}
+        error={null}
+        onUpdate={onUpdate}
+        onReset={vi.fn()}
+      />
+    );
+
+    const textareas = screen.getAllByRole('textbox');
+    fireEvent.change(textareas[0], { target: { value: 'new chat body' } });
+
+    const saveButtons = screen.getAllByRole('button', { name: /save/i });
+    fireEvent.click(saveButtons[0]);
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledWith('chat', 'new chat body');
+    });
+  });
+
+  it('calls onReset when Reset is confirmed', async () => {
+    const onReset = vi.fn().mockResolvedValue(undefined);
+    window.confirm = vi.fn().mockReturnValue(true);
+
+    render(
+      <SystemPromptSettings
+        prompts={mockPrompts}
+        isLoading={false}
+        error={null}
+        onUpdate={vi.fn()}
+        onReset={onReset}
+      />
+    );
+
+    const resetButtons = screen.getAllByRole('button', { name: /reset/i });
+    fireEvent.click(resetButtons[0]);
+
+    await waitFor(() => {
+      expect(onReset).toHaveBeenCalledWith('chat');
+    });
+  });
+
+  it('does not call onReset when Reset is cancelled', () => {
+    const onReset = vi.fn();
+    window.confirm = vi.fn().mockReturnValue(false);
+
+    render(
+      <SystemPromptSettings
+        prompts={mockPrompts}
+        isLoading={false}
+        error={null}
+        onUpdate={vi.fn()}
+        onReset={onReset}
+      />
+    );
+
+    const resetButtons = screen.getAllByRole('button', { name: /reset/i });
+    fireEvent.click(resetButtons[0]);
+
+    expect(onReset).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/SystemPromptSettings.test.tsx
+++ b/ui/src/components/SystemPromptSettings.test.tsx
@@ -25,7 +25,7 @@ describe('SystemPromptSettings', () => {
         error={null}
         onUpdate={vi.fn()}
         onReset={vi.fn()}
-      />
+      />,
     );
 
     expect(screen.getByText('Chat')).toBeInTheDocument();
@@ -40,7 +40,7 @@ describe('SystemPromptSettings', () => {
         error={null}
         onUpdate={vi.fn()}
         onReset={vi.fn()}
-      />
+      />,
     );
 
     const textareas = screen.getAllByRole('textbox');
@@ -56,7 +56,7 @@ describe('SystemPromptSettings', () => {
         error={null}
         onUpdate={vi.fn()}
         onReset={vi.fn()}
-      />
+      />,
     );
 
     const textareas = screen.getAllByRole('textbox');
@@ -76,7 +76,7 @@ describe('SystemPromptSettings', () => {
         error={null}
         onUpdate={onUpdate}
         onReset={vi.fn()}
-      />
+      />,
     );
 
     const textareas = screen.getAllByRole('textbox');
@@ -101,7 +101,7 @@ describe('SystemPromptSettings', () => {
         error={null}
         onUpdate={vi.fn()}
         onReset={onReset}
-      />
+      />,
     );
 
     const resetButtons = screen.getAllByRole('button', { name: /reset/i });
@@ -123,7 +123,7 @@ describe('SystemPromptSettings', () => {
         error={null}
         onUpdate={vi.fn()}
         onReset={onReset}
-      />
+      />,
     );
 
     const resetButtons = screen.getAllByRole('button', { name: /reset/i });
@@ -140,7 +140,7 @@ describe('SystemPromptSettings', () => {
         error={null}
         onUpdate={vi.fn()}
         onReset={vi.fn()}
-      />
+      />,
     );
 
     const details = screen.getAllByText('Available variables');
@@ -155,7 +155,7 @@ describe('SystemPromptSettings', () => {
         error={null}
         onUpdate={vi.fn()}
         onReset={vi.fn()}
-      />
+      />,
     );
 
     for (const name of ['{entry_title}', '{transcript}', '{speakers}', '{additional_context}']) {
@@ -172,7 +172,7 @@ describe('SystemPromptSettings', () => {
         error={null}
         onUpdate={vi.fn()}
         onReset={vi.fn()}
-      />
+      />,
     );
 
     const detailsElements = container.querySelectorAll('details');

--- a/ui/src/components/SystemPromptSettings.tsx
+++ b/ui/src/components/SystemPromptSettings.tsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useState } from 'react';
+
+import { SystemPrompt } from '../types';
+
+const TASK_LABELS: Record<string, string> = {
+  chat: 'Chat',
+  summary: 'Summary',
+};
+
+const TASK_DESCRIPTIONS: Record<string, string> = {
+  chat: 'System prompt sent to the AI when a user chats with a transcript. Use {entry_title} and {transcript} as placeholders.',
+  summary: 'System prompt sent to the AI when generating a transcript summary. The transcript is appended automatically.',
+};
+
+interface SystemPromptSettingsProps {
+  prompts: SystemPrompt[];
+  isLoading: boolean;
+  error: string | null;
+  onUpdate: (task: string, body: string) => Promise<void>;
+  onReset: (task: string) => Promise<void>;
+}
+
+interface CardState {
+  body: string;
+  dirty: boolean;
+  saving: boolean;
+  saveError: string | null;
+}
+
+export const SystemPromptSettings: React.FC<SystemPromptSettingsProps> = ({
+  prompts,
+  isLoading,
+  error,
+  onUpdate,
+  onReset,
+}) => {
+  const [cardStates, setCardStates] = useState<Record<string, CardState>>({});
+
+  useEffect(() => {
+    const initial: Record<string, CardState> = {};
+    for (const prompt of prompts) {
+      initial[prompt.task] = {
+        body: prompt.body,
+        dirty: false,
+        saving: false,
+        saveError: null,
+      };
+    }
+    setCardStates(initial);
+  }, [prompts]);
+
+  const handleChange = (task: string, value: string) => {
+    setCardStates((prev) => ({
+      ...prev,
+      [task]: { ...prev[task], body: value, dirty: true, saveError: null },
+    }));
+  };
+
+  const handleSave = async (task: string) => {
+    const body = cardStates[task]?.body ?? '';
+    setCardStates((prev) => ({
+      ...prev,
+      [task]: { ...prev[task], saving: true, saveError: null },
+    }));
+
+    try {
+      await onUpdate(task, body);
+      setCardStates((prev) => ({
+        ...prev,
+        [task]: { ...prev[task], saving: false, dirty: false },
+      }));
+    } catch {
+      setCardStates((prev) => ({
+        ...prev,
+        [task]: {
+          ...prev[task],
+          saving: false,
+          saveError: 'Failed to save. Please try again.',
+        },
+      }));
+    }
+  };
+
+  const handleReset = async (task: string) => {
+    if (!window.confirm('Reset this prompt to its default? Your edits will be lost.')) {
+      return;
+    }
+
+    setCardStates((prev) => ({
+      ...prev,
+      [task]: { ...prev[task], saving: true, saveError: null },
+    }));
+
+    try {
+      await onReset(task);
+    } finally {
+      setCardStates((prev) => ({
+        ...prev,
+        [task]: { ...prev[task], saving: false, dirty: false },
+      }));
+    }
+  };
+
+  if (isLoading) {
+    return <div className="p-6 text-sm text-gray-500">Loading system prompts...</div>;
+  }
+
+  if (error) {
+    return <div className="p-6 text-sm text-red-600">{error}</div>;
+  }
+
+  const tasks = ['chat', 'summary'];
+
+  return (
+    <div className="flex flex-col gap-4 p-6">
+      {tasks.map((task) => {
+        const state = cardStates[task];
+        if (!state) {
+          return null;
+        }
+
+        return (
+          <div key={task} className="rounded-lg border border-gray-200 bg-white p-4">
+            <div className="mb-1 text-sm font-semibold text-gray-800">{TASK_LABELS[task]}</div>
+            <div className="mb-3 text-xs text-gray-500">{TASK_DESCRIPTIONS[task]}</div>
+            <textarea
+              className="w-full rounded border border-gray-300 p-2 font-mono text-xs leading-relaxed focus:outline-none focus:ring-2 focus:ring-blue-500"
+              rows={8}
+              value={state.body}
+              onChange={(event) => handleChange(task, event.target.value)}
+            />
+            {state.saveError && <div className="mt-1 text-xs text-red-600">{state.saveError}</div>}
+            <div className="mt-3 flex gap-2">
+              <button
+                className="rounded bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                disabled={!state.dirty || state.saving}
+                onClick={() => handleSave(task)}
+              >
+                {state.saving ? 'Saving...' : 'Save'}
+              </button>
+              <button
+                className="rounded border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 disabled:opacity-50"
+                disabled={state.saving}
+                onClick={() => handleReset(task)}
+              >
+                Reset to default
+              </button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/ui/src/components/SystemPromptSettings.tsx
+++ b/ui/src/components/SystemPromptSettings.tsx
@@ -8,8 +8,23 @@ const TASK_LABELS: Record<string, string> = {
 };
 
 const TASK_DESCRIPTIONS: Record<string, string> = {
-  chat: 'System prompt sent to the AI when a user chats with a transcript. Use {entry_title} and {transcript} as placeholders.',
-  summary: 'System prompt sent to the AI when generating a transcript summary. The transcript is appended automatically.',
+  chat: 'System prompt sent to the AI when a user chats with a transcript.',
+  summary: 'System prompt sent to the AI when generating a transcript summary. The transcript is passed as the user message; placeholders below let you also reference entry data inside the system prompt.',
+};
+
+const TASK_VARIABLES: Record<string, Array<{ name: string; description: string }>> = {
+  chat: [
+    { name: 'entry_title', description: 'Title of the entry' },
+    { name: 'transcript', description: 'Full transcript text' },
+    { name: 'speakers', description: 'Speakers list (may be empty)' },
+    { name: 'additional_context', description: 'Additional context (may be empty)' },
+  ],
+  summary: [
+    { name: 'entry_title', description: 'Title of the entry' },
+    { name: 'transcript', description: 'Full transcript text' },
+    { name: 'speakers', description: 'Speakers list (may be empty)' },
+    { name: 'additional_context', description: 'Additional context (may be empty)' },
+  ],
 };
 
 interface SystemPromptSettingsProps {
@@ -122,7 +137,20 @@ export const SystemPromptSettings: React.FC<SystemPromptSettingsProps> = ({
         return (
           <div key={task} className="rounded-lg border border-gray-200 bg-white p-4">
             <div className="mb-1 text-sm font-semibold text-gray-800">{TASK_LABELS[task]}</div>
-            <div className="mb-3 text-xs text-gray-500">{TASK_DESCRIPTIONS[task]}</div>
+            <div className="mb-2 text-xs text-gray-500">{TASK_DESCRIPTIONS[task]}</div>
+            <details className="mb-3 text-xs text-gray-500">
+              <summary className="cursor-pointer select-none">Available variables</summary>
+              <ul className="mt-2 space-y-1 pl-4">
+                {TASK_VARIABLES[task].map((v) => (
+                  <li key={v.name}>
+                    <code className="rounded bg-gray-100 px-1 py-0.5 font-mono text-[11px]">
+                      {`{${v.name}}`}
+                    </code>
+                    <span className="ml-2">— {v.description}</span>
+                  </li>
+                ))}
+              </ul>
+            </details>
             <textarea
               className="w-full rounded border border-gray-300 p-2 font-mono text-xs leading-relaxed focus:outline-none focus:ring-2 focus:ring-blue-500"
               rows={8}

--- a/ui/src/components/SystemPromptSettings.tsx
+++ b/ui/src/components/SystemPromptSettings.tsx
@@ -9,7 +9,8 @@ const TASK_LABELS: Record<string, string> = {
 
 const TASK_DESCRIPTIONS: Record<string, string> = {
   chat: 'System prompt sent to the AI when a user chats with a transcript.',
-  summary: 'System prompt sent to the AI when generating a transcript summary. The transcript is passed as the user message; placeholders below let you also reference entry data inside the system prompt.',
+  summary:
+    'System prompt sent to the AI when generating a transcript summary. The transcript is passed as the user message; placeholders below let you also reference entry data inside the system prompt.',
 };
 
 const TASK_VARIABLES: Record<string, Array<{ name: string; description: string }>> = {

--- a/ui/src/services/api.ts
+++ b/ui/src/services/api.ts
@@ -11,6 +11,7 @@ import {
   PromptTemplate,
   PromptTemplateCreate,
   PromptTemplateUpdate,
+  SystemPrompt,
 } from '../types';
 
 const api = axios.create({
@@ -139,6 +140,22 @@ export const entryApi = {
 
   deletePromptTemplate: async (id: string): Promise<void> => {
     await api.delete(`/prompt-templates/${id}`);
+  },
+
+  // System prompts
+  getSystemPrompts: async (): Promise<SystemPrompt[]> => {
+    const response = await api.get('/system-prompts/');
+    return response.data;
+  },
+
+  updateSystemPrompt: async (task: string, body: string): Promise<SystemPrompt> => {
+    const response = await api.put(`/system-prompts/${task}`, { body });
+    return response.data;
+  },
+
+  resetSystemPrompt: async (task: string): Promise<SystemPrompt> => {
+    const response = await api.post(`/system-prompts/${task}/reset`);
+    return response.data;
   },
 
   // Chat with entry

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -112,3 +112,9 @@ export interface PromptTemplateUpdate {
   sort_order?: number;
   is_active?: boolean;
 }
+
+export interface SystemPrompt {
+  task: 'chat' | 'summary';
+  body: string;
+  updated_at: string;
+}


### PR DESCRIPTION
Introduces a new system for managing system prompts for AI chat and summary tasks, making prompts customizable and editable via API endpoints. It refactors the chat and summary logic to use these database-backed prompts, improving flexibility and maintainability. The main changes are grouped as follows:

**System Prompt Management:**

* Added a new `SystemPrompt` SQLAlchemy model and database table to store system prompts for different tasks (`chat`, `summary`).
* Implemented `SystemPromptService` to manage fetching, rendering (with entry context), updating, resetting, and seeding default system prompts.
* Added API endpoints in `system_prompts.py` to list, update, and reset system prompts, making them editable via the API.

**Integration with Chat and Summary Features:**

* Refactored chat and summary endpoints and service logic to use the rendered system prompts from the database instead of hardcoded strings, allowing for dynamic prompt customization.

**Supporting Changes:**

* Added new Pydantic schemas for system prompt API responses and updates.
* Registered the new model and API route in the application and models init files.

These changes make system prompts first-class, editable resources, enabling admins or future UI features to modify prompt behavior without code changes.