### PR TITLE
Extend add modal and meta data modal to store language of provided content

### DIFF
--- a/api/app/api/routes/entries.py
+++ b/api/app/api/routes/entries.py
@@ -19,6 +19,7 @@ from app.models.schemas import (
     ChatRequest,
     ChatResponse,
     SummaryResponse,
+    _normalize_language,
 )
 from app.services.entry_service import EntryService
 from app.services.s3_service import S3Service
@@ -33,10 +34,13 @@ router = APIRouter()
 async def upload_file(
     title: str = Form(...),
     file: UploadFile = File(...),
+    language: str | None = Form(default=None),
     db: Session = Depends(get_db),
     current_user: bool = Depends(get_current_user),
 ):
     """Upload audio or video file"""
+
+    language = _normalize_language(language)
 
     # Validate file type
     file_extension = file.filename.split(".")[-1].lower()
@@ -67,6 +71,7 @@ async def upload_file(
         title=title,
         source_type=SourceType.UPLOAD,
         filename=file.filename,
+        language=language,
     )
 
     # Initialize S3 service
@@ -118,6 +123,7 @@ async def create_from_url(
         title=entry_data.title,
         source_type=SourceType.URL,
         source_url=str(entry_data.source_url),
+        language=entry_data.language,
     )
 
     # TODO: Start background processing for URL download and ASR
@@ -143,6 +149,7 @@ async def create_from_transcript(
     entry = entry_service.create_transcript_entry(
         title=title,
         transcript=transcript,
+        language=entry_data.language,
     )
 
     return EntryResponse.from_orm(entry)
@@ -236,12 +243,19 @@ async def update_entry_metadata(
     )
 
     regenerate = metadata_update.regenerate_transcript
-    if not title and not speakers and not additional_context and not regenerate:
+    update_language = metadata_update.language_set
+    if (
+        not title
+        and not speakers
+        and not additional_context
+        and not regenerate
+        and not update_language
+    ):
         raise HTTPException(
             status_code=400,
             detail=(
                 "At least one of 'title', 'speakers', 'additional_context', "
-                "or 'regenerate_transcript' must be provided."
+                "'language', or 'regenerate_transcript' must be provided."
             ),
         )
 
@@ -251,6 +265,8 @@ async def update_entry_metadata(
         speakers=speakers or None,
         additional_context=additional_context or None,
         title=title,
+        language=metadata_update.language,
+        update_language=update_language,
     )
 
     if not entry:

--- a/api/app/models/entry.py
+++ b/api/app/models/entry.py
@@ -37,6 +37,7 @@ class Entry(Base):
     summary = Column(Text, nullable=True)
     speakers = Column(Text, nullable=True)
     additional_context = Column(Text, nullable=True)
+    language = Column(String(16), nullable=True)
     error_message = Column(Text, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/api/app/models/schemas.py
+++ b/api/app/models/schemas.py
@@ -7,6 +7,18 @@ from uuid import UUID
 from .entry import EntryStatus, SourceType
 
 
+def _normalize_language(value: Any) -> Any:
+    """Treat empty / 'auto' as None; otherwise lowercase + strip the ISO code."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        cleaned = value.strip().lower()
+        if not cleaned or cleaned == "auto":
+            return None
+        return cleaned
+    return value
+
+
 class TranscriptWord(BaseModel):
     """A single transcribed word with start/end timestamps in seconds (millisecond precision)."""
 
@@ -26,19 +38,37 @@ class TranscriptSegment(BaseModel):
 class EntryCreate(BaseModel):
     title: str
     source_url: HttpUrl | None = None
+    language: str | None = Field(default=None, max_length=16)
 
     model_config = {"from_attributes": True}
+
+    @field_validator("language", mode="before")
+    @classmethod
+    def _norm_language(cls, value: Any) -> Any:
+        return _normalize_language(value)
 
 
 class EntryTranscriptCreate(BaseModel):
     title: str
     transcript: str = Field(..., min_length=1)
+    language: str | None = Field(default=None, max_length=16)
 
     model_config = {"from_attributes": True}
+
+    @field_validator("language", mode="before")
+    @classmethod
+    def _norm_language(cls, value: Any) -> Any:
+        return _normalize_language(value)
 
 
 class EntryUpload(BaseModel):
     title: str
+    language: str | None = Field(default=None, max_length=16)
+
+    @field_validator("language", mode="before")
+    @classmethod
+    def _norm_language(cls, value: Any) -> Any:
+        return _normalize_language(value)
 
 
 def _parse_json_list(value: Any) -> Any:
@@ -73,6 +103,7 @@ class EntryResponse(BaseModel):
     summary: str | None = None
     speakers: str | None = None
     additional_context: str | None = None
+    language: str | None = None
     error_message: str | None = None
     created_at: datetime
     updated_at: datetime
@@ -109,7 +140,14 @@ class EntryMetadataUpdate(BaseModel):
     title: str | None = Field(default=None, min_length=1, max_length=255)
     speakers: str | None = Field(default=None, max_length=2000)
     additional_context: str | None = Field(default=None, max_length=5000)
+    language: str | None = Field(default=None, max_length=16)
+    language_set: bool = False
     regenerate_transcript: bool = False
+
+    @field_validator("language", mode="before")
+    @classmethod
+    def _norm_language(cls, value: Any) -> Any:
+        return _normalize_language(value)
 
 
 class EntryList(BaseModel):

--- a/api/app/services/entry_service.py
+++ b/api/app/services/entry_service.py
@@ -19,6 +19,7 @@ class EntryService:
         filename: str | None = None,
         status: EntryStatus = EntryStatus.NEW,
         transcript: str | None = None,
+        language: str | None = None,
     ) -> Entry:
         """Create a new entry"""
 
@@ -29,6 +30,7 @@ class EntryService:
             filename=filename,
             status=status,
             transcript=transcript,
+            language=language,
         )
 
         self.db.add(entry)
@@ -37,7 +39,12 @@ class EntryService:
 
         return entry
 
-    def create_transcript_entry(self, title: str, transcript: str) -> Entry:
+    def create_transcript_entry(
+        self,
+        title: str,
+        transcript: str,
+        language: str | None = None,
+    ) -> Entry:
         """Create a ready entry from an existing transcript."""
 
         return self.create_entry(
@@ -45,6 +52,7 @@ class EntryService:
             source_type=SourceType.UPLOAD,
             status=EntryStatus.READY,
             transcript=transcript,
+            language=language,
         )
 
     def get_entry(self, entry_id: UUID) -> Entry | None:
@@ -187,8 +195,10 @@ class EntryService:
         speakers: str | None,
         additional_context: str | None,
         title: str | None = None,
+        language: str | None = None,
+        update_language: bool = False,
     ) -> Entry | None:
-        """Update title and custom metadata (speakers, additional context) for an entry."""
+        """Update title and custom metadata (speakers, additional context, language) for an entry."""
 
         entry = self.get_entry(entry_id)
         if not entry:
@@ -198,6 +208,8 @@ class EntryService:
             entry.title = title
         entry.speakers = speakers
         entry.additional_context = additional_context
+        if update_language:
+            entry.language = language
         self.db.commit()
         self.db.refresh(entry)
 

--- a/ui/src/components/EntryForm.tsx
+++ b/ui/src/components/EntryForm.tsx
@@ -4,6 +4,7 @@ import { Dialog, Transition } from '@headlessui/react';
 import { Upload, Link, Loader2, X, FileText } from 'lucide-react';
 import { entryApi } from '../services/api';
 import { Entry } from '../types';
+import { LanguageSelect } from './LanguageSelect';
 
 interface EntryFormProps {
   onEntryCreated: (entry: Entry) => void;
@@ -29,6 +30,7 @@ export const EntryForm: React.FC<EntryFormProps> = ({ onEntryCreated, onClose })
   const [url, setUrl] = useState('');
   const [transcript, setTranscript] = useState('');
   const [file, setFile] = useState<File | null>(null);
+  const [language, setLanguage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -61,6 +63,7 @@ export const EntryForm: React.FC<EntryFormProps> = ({ onEntryCreated, onClose })
         entry = await entryApi.createFromUrl({
           title: title.trim() || new URL(url).hostname,
           source_url: url.trim(),
+          language: language ?? undefined,
         });
       } else if (submissionType === 'transcript') {
         if (!transcript.trim()) {
@@ -69,12 +72,13 @@ export const EntryForm: React.FC<EntryFormProps> = ({ onEntryCreated, onClose })
         entry = await entryApi.createFromTranscript({
           title: title.trim() || getTranscriptFallbackTitle(transcript),
           transcript: transcript.trim(),
+          language: language ?? undefined,
         });
       } else {
         if (!file) {
           throw new Error('File is required');
         }
-        entry = await entryApi.uploadFile(title.trim() || file.name, file);
+        entry = await entryApi.uploadFile(title.trim() || file.name, file, language);
       }
 
       onEntryCreated(entry);
@@ -83,6 +87,7 @@ export const EntryForm: React.FC<EntryFormProps> = ({ onEntryCreated, onClose })
       setUrl('');
       setTranscript('');
       setFile(null);
+      setLanguage(null);
       onClose();
     } catch (err) {
       const detail = axios.isAxiosError(err) ? err.response?.data?.detail : undefined;
@@ -242,6 +247,27 @@ export const EntryForm: React.FC<EntryFormProps> = ({ onEntryCreated, onClose })
                       className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
                     />
                   </div>
+
+                  {submissionType !== 'transcript' && (
+                    <div>
+                      <label
+                        htmlFor="entry-language"
+                        className="block text-sm font-medium text-gray-700 mb-1"
+                      >
+                        Audio language
+                      </label>
+                      <LanguageSelect
+                        id="entry-language"
+                        value={language}
+                        onChange={setLanguage}
+                        disabled={isSubmitting}
+                      />
+                      <p className="mt-1 text-xs text-gray-500">
+                        Auto-detect works for most recordings. Set explicitly if the audio is in a
+                        single known language to improve accuracy.
+                      </p>
+                    </div>
+                  )}
 
                   {submissionType === 'url' && (
                     <div>

--- a/ui/src/components/EntryMetadataModal.tsx
+++ b/ui/src/components/EntryMetadataModal.tsx
@@ -3,6 +3,7 @@ import { Dialog, Transition } from '@headlessui/react';
 import { Loader2, RefreshCw, X } from 'lucide-react';
 import { entryApi } from '../services/api';
 import { Entry } from '../types';
+import { LanguageSelect } from './LanguageSelect';
 
 const TITLE_MAX = 255;
 const SPEAKERS_MAX = 2000;
@@ -24,6 +25,8 @@ export const EntryMetadataModal: React.FC<EntryMetadataModalProps> = ({
   const [title, setTitle] = useState(entry.title);
   const [speakers, setSpeakers] = useState(entry.speakers ?? '');
   const [additionalContext, setAdditionalContext] = useState(entry.additional_context ?? '');
+  const [language, setLanguage] = useState<string | null>(entry.language ?? null);
+  const [languageTouched, setLanguageTouched] = useState(false);
   const [regenerateTranscript, setRegenerateTranscript] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -38,6 +41,8 @@ export const EntryMetadataModal: React.FC<EntryMetadataModalProps> = ({
       setTitle(entry.title);
       setSpeakers(entry.speakers ?? '');
       setAdditionalContext(entry.additional_context ?? '');
+      setLanguage(entry.language ?? null);
+      setLanguageTouched(false);
       setRegenerateTranscript(false);
       setError(null);
     }
@@ -73,6 +78,8 @@ export const EntryMetadataModal: React.FC<EntryMetadataModalProps> = ({
         title: trimmedTitle,
         speakers: trimmedSpeakers || undefined,
         additional_context: trimmedContext || undefined,
+        language: languageTouched ? language : undefined,
+        language_set: languageTouched || undefined,
         regenerate_transcript: regenerateTranscript && canRegenerate ? true : undefined,
       });
       onSaved(updated);
@@ -219,6 +226,29 @@ export const EntryMetadataModal: React.FC<EntryMetadataModalProps> = ({
                           {additionalContext.length}/{ADDITIONAL_CONTEXT_MAX}
                         </span>
                       </div>
+                    </div>
+
+                    <div>
+                      <label
+                        htmlFor="entry-language"
+                        className="block text-sm font-medium text-gray-700"
+                      >
+                        Audio language
+                      </label>
+                      <LanguageSelect
+                        id="entry-language"
+                        value={language}
+                        onChange={(value) => {
+                          setLanguage(value);
+                          setLanguageTouched(true);
+                        }}
+                        disabled={isSaving}
+                        className="mt-1"
+                      />
+                      <p className="mt-1 text-xs text-gray-500">
+                        Used by the ASR provider on the next transcription. Tick &ldquo;Regenerate
+                        transcript&rdquo; below to re-run ASR with this language now.
+                      </p>
                     </div>
 
                     <div className="rounded-md border border-gray-200 bg-gray-50 p-3">

--- a/ui/src/components/LanguageSelect.tsx
+++ b/ui/src/components/LanguageSelect.tsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+// ISO 639-1 codes Whisper understands. Auto is represented as null.
+const CURATED_LANGUAGES: { code: string; label: string }[] = [
+  { code: 'en', label: 'English' },
+  { code: 'de', label: 'German' },
+  { code: 'es', label: 'Spanish' },
+  { code: 'fr', label: 'French' },
+  { code: 'it', label: 'Italian' },
+  { code: 'nl', label: 'Dutch' },
+  { code: 'pt', label: 'Portuguese' },
+  { code: 'pl', label: 'Polish' },
+  { code: 'ru', label: 'Russian' },
+  { code: 'tr', label: 'Turkish' },
+  { code: 'ar', label: 'Arabic' },
+  { code: 'hi', label: 'Hindi' },
+  { code: 'zh', label: 'Chinese' },
+  { code: 'ja', label: 'Japanese' },
+  { code: 'ko', label: 'Korean' },
+];
+
+const CURATED_CODES = new Set(CURATED_LANGUAGES.map((entry) => entry.code));
+const OTHER_VALUE = '__other__';
+const AUTO_VALUE = '__auto__';
+
+interface LanguageSelectProps {
+  id?: string;
+  value: string | null | undefined;
+  onChange: (value: string | null) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+const normalize = (value: string | null | undefined): string | null => {
+  if (!value) return null;
+  const cleaned = value.trim().toLowerCase();
+  if (!cleaned || cleaned === 'auto') return null;
+  return cleaned;
+};
+
+export const LanguageSelect: React.FC<LanguageSelectProps> = ({
+  id,
+  value,
+  onChange,
+  disabled,
+  className,
+}) => {
+  const normalized = useMemo(() => normalize(value), [value]);
+  const startsAsCustom = normalized !== null && !CURATED_CODES.has(normalized);
+  const [isCustom, setIsCustom] = useState(startsAsCustom);
+  const [customDraft, setCustomDraft] = useState(startsAsCustom ? (normalized ?? '') : '');
+
+  // Re-sync local state when an external value change moves us in or out of "custom".
+  useEffect(() => {
+    if (normalized === null) {
+      setIsCustom(false);
+      setCustomDraft('');
+    } else if (CURATED_CODES.has(normalized)) {
+      setIsCustom(false);
+    } else {
+      setIsCustom(true);
+      setCustomDraft(normalized);
+    }
+  }, [normalized]);
+
+  const selectValue = isCustom ? OTHER_VALUE : (normalized ?? AUTO_VALUE);
+
+  const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const next = event.target.value;
+    if (next === AUTO_VALUE) {
+      setIsCustom(false);
+      setCustomDraft('');
+      onChange(null);
+    } else if (next === OTHER_VALUE) {
+      setIsCustom(true);
+      onChange(normalize(customDraft));
+    } else {
+      setIsCustom(false);
+      onChange(next);
+    }
+  };
+
+  const handleCustomChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = event.target.value;
+    setCustomDraft(raw);
+    onChange(normalize(raw));
+  };
+
+  return (
+    <div className={className}>
+      <select
+        id={id}
+        value={selectValue}
+        onChange={handleSelectChange}
+        disabled={disabled}
+        className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 disabled:bg-gray-50 disabled:text-gray-500"
+      >
+        <option value={AUTO_VALUE}>Auto-detect</option>
+        {CURATED_LANGUAGES.map((entry) => (
+          <option key={entry.code} value={entry.code}>
+            {entry.label} ({entry.code})
+          </option>
+        ))}
+        <option value={OTHER_VALUE}>Other (custom ISO 639-1 code)</option>
+      </select>
+      {isCustom && (
+        <input
+          type="text"
+          value={customDraft}
+          onChange={handleCustomChange}
+          disabled={disabled}
+          maxLength={16}
+          placeholder="e.g. sv, uk, vi"
+          className="mt-2 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 disabled:bg-gray-50 disabled:text-gray-500"
+          aria-label="Custom language code"
+        />
+      )}
+    </div>
+  );
+};

--- a/ui/src/services/api.ts
+++ b/ui/src/services/api.ts
@@ -78,10 +78,13 @@ export const entryApi = {
   },
 
   // Upload file
-  uploadFile: async (title: string, file: File): Promise<Entry> => {
+  uploadFile: async (title: string, file: File, language?: string | null): Promise<Entry> => {
     const formData = new FormData();
     formData.append('title', title);
     formData.append('file', file);
+    if (language) {
+      formData.append('language', language);
+    }
 
     const response = await api.post('/entries/upload', formData, {
       headers: {

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -28,6 +28,7 @@ export interface Entry {
   summary?: string;
   speakers?: string;
   additional_context?: string;
+  language?: string | null;
   error_message?: string;
   created_at: string;
   updated_at: string;
@@ -37,17 +38,21 @@ export interface EntryMetadataUpdate {
   title?: string;
   speakers?: string;
   additional_context?: string;
+  language?: string | null;
+  language_set?: boolean;
   regenerate_transcript?: boolean;
 }
 
 export interface EntryCreate {
   title: string;
   source_url?: string;
+  language?: string | null;
 }
 
 export interface EntryTranscriptCreate {
   title: string;
   transcript: string;
+  language?: string | null;
 }
 
 export interface EntryList {

--- a/worker/app/models/entry.py
+++ b/worker/app/models/entry.py
@@ -38,6 +38,7 @@ class Entry(Base):
     summary = Column(Text, nullable=True)
     speakers = Column(Text, nullable=True)
     additional_context = Column(Text, nullable=True)
+    language = Column(String(16), nullable=True)
     error_message = Column(Text, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/worker/app/services/asr_service.py
+++ b/worker/app/services/asr_service.py
@@ -62,6 +62,7 @@ class ASRService:
         self,
         s3_key: str,
         entry_id: str,
+        language: str | None = None,
     ) -> tuple[
         bool,
         str | None,
@@ -119,24 +120,41 @@ class ASRService:
             return False, None, None, None, error_msg
 
         try:
+            if language:
+                logger.info(f"Entry {entry_id}: Forcing ASR language to '{language}'")
+            else:
+                logger.info(f"Entry {entry_id}: Using auto language detection")
+
             # Whisper ASR webservice has no inherent file limit, so skip chunking
             if self.provider == ASRProvider.WHISPER_ASR:
                 logger.info(
                     f"Entry {entry_id}: Using whisper-asr-webservice (no chunking needed)",
                 )
-                return await self._transcribe_single_file(temp_file_path, entry_id)
+                return await self._transcribe_single_file(
+                    temp_file_path,
+                    entry_id,
+                    language,
+                )
 
             # Use the actual file size that will be sent to Groq for chunking decision
             if file_size > settings.max_file_size:
                 logger.info(
                     f"Entry {entry_id}: File size ({file_size}) exceeds Groq limit ({settings.max_file_size}), using chunked transcription",
                 )
-                return await self._transcribe_chunked_file(temp_file_path, entry_id)
+                return await self._transcribe_chunked_file(
+                    temp_file_path,
+                    entry_id,
+                    language,
+                )
             else:
                 logger.info(
                     f"Entry {entry_id}: File size ({file_size}) is within Groq limits, using direct single API call",
                 )
-                return await self._transcribe_single_file(temp_file_path, entry_id)
+                return await self._transcribe_single_file(
+                    temp_file_path,
+                    entry_id,
+                    language,
+                )
 
         except Exception as e:
             error_msg = f"Transcription error: {str(e)}"
@@ -150,6 +168,7 @@ class ASRService:
         self,
         temp_file_path: str,
         entry_id: str,
+        language: str | None = None,
     ) -> tuple[
         bool,
         str | None,
@@ -169,7 +188,11 @@ class ASRService:
                     logger.warning(
                         f"Entry {entry_id}: File size {file_size} exceeds Groq limit {settings.max_file_size}, falling back to chunking",
                     )
-                    return await self._transcribe_chunked_file(temp_file_path, entry_id)
+                    return await self._transcribe_chunked_file(
+                        temp_file_path,
+                        entry_id,
+                        language,
+                    )
                 logger.info(f"Entry {entry_id}: File size {file_size} bytes")
 
             logger.info(f"Entry {entry_id}: Starting single file transcription")
@@ -182,6 +205,7 @@ class ASRService:
                 temp_file_path,
                 None,
                 entry_id,
+                language,
             )
 
             if transcript:
@@ -205,6 +229,7 @@ class ASRService:
         self,
         temp_file_path: str,
         entry_id: str,
+        language: str | None = None,
     ) -> tuple[
         bool,
         str | None,
@@ -243,7 +268,11 @@ class ASRService:
                     f"Entry {entry_id}: File doesn't need chunking, processing as single file",
                 )
                 cleanup_chunks = False  # Don't clean up the original file
-                return await self._transcribe_single_file(temp_file_path, entry_id)
+                return await self._transcribe_single_file(
+                    temp_file_path,
+                    entry_id,
+                    language,
+                )
 
             logger.info(
                 f"Entry {entry_id}: Processing {len(chunk_paths)} chunks sequentially (multiple API calls to respect size limits)",
@@ -293,6 +322,7 @@ class ASRService:
                         chunk_path,
                         None,
                         f"{entry_id}_chunk_{i + 1}",
+                        language,
                     )
 
                     if chunk_transcript:
@@ -426,18 +456,20 @@ class ASRService:
         file_path: str,
         s3_key: str = None,
         entry_id: str = None,
+        language: str | None = None,
     ) -> tuple[str | None, list[dict[str, Any]] | None, list[dict[str, Any]] | None]:
         """Synchronous transcription returning (text, words, segments).
 
         Each list element is a dict with timestamps in seconds rounded to
         millisecond precision. words have shape {"word", "start", "end"} and
         segments have shape {"text", "start", "end"}. Either list may be None
-        if the provider didn't return that granularity.
+        if the provider didn't return that granularity. `language` is an ISO
+        639-1 code that forces detection; None means auto-detect.
         """
         if self.provider == ASRProvider.GROQ:
-            return self._transcribe_groq_sync(file_path, entry_id)
+            return self._transcribe_groq_sync(file_path, entry_id, language)
         elif self.provider == ASRProvider.WHISPER_ASR:
-            return self._transcribe_whisper_asr_sync(file_path, entry_id)
+            return self._transcribe_whisper_asr_sync(file_path, entry_id, language)
         else:
             raise ValueError(f"Unsupported ASR provider: {self.provider}")
 
@@ -483,6 +515,7 @@ class ASRService:
         self,
         file_path: str,
         entry_id: str = None,
+        language: str | None = None,
     ) -> tuple[str | None, list[dict[str, Any]] | None, list[dict[str, Any]] | None]:
         """Synchronous Groq transcription with word-level timestamps"""
         try:
@@ -533,13 +566,16 @@ class ASRService:
                 # Request verbose_json with both word- and segment-level
                 # timestamps so we can fall back to segments when callers don't
                 # need or have word-level granularity.
-                transcription = self.client.audio.transcriptions.create(
-                    file=(file_name, audio_file, "audio/mpeg"),
-                    model=self.model,
-                    response_format="verbose_json",
-                    timestamp_granularities=["word", "segment"],
-                    temperature=0.0,
-                )
+                groq_kwargs: dict[str, Any] = {
+                    "file": (file_name, audio_file, "audio/mpeg"),
+                    "model": self.model,
+                    "response_format": "verbose_json",
+                    "timestamp_granularities": ["word", "segment"],
+                    "temperature": 0.0,
+                }
+                if language:
+                    groq_kwargs["language"] = language
+                transcription = self.client.audio.transcriptions.create(**groq_kwargs)
 
                 text: str | None = None
                 raw_words: list[Any] = []
@@ -591,6 +627,7 @@ class ASRService:
         self,
         file_path: str,
         entry_id: str = None,
+        language: str | None = None,
     ) -> tuple[str | None, list[dict[str, Any]] | None, list[dict[str, Any]] | None]:
         """Synchronous whisper-asr-webservice transcription with word-level timestamps"""
         try:
@@ -608,6 +645,8 @@ class ASRService:
                     "encode": "true",
                     "word_timestamps": "true",
                 }
+                if language:
+                    params["language"] = language
 
                 logger.info(
                     f"Entry {entry_id or 'unknown'}: Sending to whisper-asr-webservice at {self.whisper_asr_url}/asr",

--- a/worker/app/services/database.py
+++ b/worker/app/services/database.py
@@ -47,6 +47,11 @@ def ensure_entry_schema() -> None:
             text("ALTER TABLE entries ADD COLUMN transcript_segments TEXT"),
         )
 
+    if "language" not in columns:
+        statements.append(
+            text("ALTER TABLE entries ADD COLUMN language VARCHAR(16)"),
+        )
+
     if not statements:
         return
 

--- a/worker/app/services/worker_service.py
+++ b/worker/app/services/worker_service.py
@@ -205,6 +205,7 @@ class WorkerService:
             ) = await self.asr_service.transcribe_file(
                 entry.file_path,
                 str(entry.id),
+                language=getattr(entry, "language", None) or None,
             )
 
             # Debug logging to see what's returned


### PR DESCRIPTION
Adds support for specifying and updating the language of an audio or transcript entry throughout the stack (backend, API, and UI). Language can now be set when creating or uploading entries, and edited in the entry metadata modal. The backend normalizes language codes and stores them in the database, and the UI provides a language selection component. 

These changes ensure language is a first-class, user-editable property on entries, improving transcription accuracy and user control.