### PR TITLE
docs: default to GHCR published images and add Compose pull policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Container Registry and Versioning
-REGISTRY=
+# Published images are available as ghcr.io/nezhar/voicevault-ui, -api, and -worker.
+# Leave REGISTRY empty when you want Docker Compose to build local image names.
+REGISTRY=ghcr.io/nezhar/
 VERSION=latest
 
 # Database Configuration

--- a/.env.production
+++ b/.env.production
@@ -2,7 +2,8 @@
 # Copy this file to .env and configure with your actual values
 
 # Container Registry and Versioning
-REGISTRY=your-registry.com/your-project/
+# Published images are available as ghcr.io/nezhar/voicevault-ui, -api, and -worker.
+REGISTRY=ghcr.io/nezhar/
 VERSION=latest
 
 # Authentication (Required for production)

--- a/README.md
+++ b/README.md
@@ -45,8 +45,19 @@ git clone https://github.com/your-username/voicevault.git
 cd voicevault
 cp .env.example .env
 # Edit .env — at minimum set GROQ_API_KEY (or configure an alternative provider)
-docker compose up --build
+# Uses published images from ghcr.io/nezhar by default; add --build to rebuild locally.
+docker compose up
 ```
+
+Published service images are available from GitHub Container Registry:
+
+| Service | Image |
+|---------|-------|
+| Frontend | `ghcr.io/nezhar/voicevault-ui:latest` |
+| API | `ghcr.io/nezhar/voicevault-api:latest` |
+| Worker | `ghcr.io/nezhar/voicevault-worker:latest` |
+
+Pull them directly with `docker compose pull`, or pin `VERSION` in `.env` to a release tag such as `0.4.0`.
 
 | Service | URL |
 |---------|-----|

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,5 +1,5 @@
 # Production compose file with self-contained containers
-# Usage: docker compose -f compose.prod.yml up -d --build
+# Usage: docker compose -f compose.prod.yml pull && docker compose -f compose.prod.yml up -d
 
 services:
   ui:
@@ -7,6 +7,7 @@ services:
       context: ./ui
       dockerfile: Dockerfile
     image: ${REGISTRY:-}voicevault-ui:${VERSION:-latest}
+    pull_policy: missing
     ports:
       - "${UI_PORT:-3000}:80"
     environment:
@@ -20,6 +21,7 @@ services:
       context: ./api
       dockerfile: Dockerfile
     image: ${REGISTRY:-}voicevault-api:${VERSION:-latest}
+    pull_policy: missing
     ports:
       - "${API_PORT:-8000}:8000"
     environment:
@@ -45,6 +47,7 @@ services:
       context: ./worker
       dockerfile: Dockerfile
     image: ${REGISTRY:-}voicevault-worker:${VERSION:-latest}
+    pull_policy: missing
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT:-5432}/${POSTGRES_DB}
       - WORKER_MODE=download
@@ -64,6 +67,7 @@ services:
       context: ./worker
       dockerfile: Dockerfile
     image: ${REGISTRY:-}voicevault-worker:${VERSION:-latest}
+    pull_policy: missing
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT:-5432}/${POSTGRES_DB}
       - WORKER_MODE=asr

--- a/compose.yml
+++ b/compose.yml
@@ -4,6 +4,7 @@ services:
       context: ./ui
       dockerfile: Dockerfile
     image: ${REGISTRY:-}voicevault-ui:${VERSION:-latest}
+    pull_policy: missing
     ports:
       - "${UI_PORT:-3000}:80"
     environment:
@@ -18,6 +19,7 @@ services:
       context: ./api
       dockerfile: Dockerfile
     image: ${REGISTRY:-}voicevault-api:${VERSION:-latest}
+    pull_policy: missing
     ports:
       - "${API_PORT:-8000}:8000"
     environment:
@@ -51,6 +53,7 @@ services:
       context: ./worker
       dockerfile: Dockerfile
     image: ${REGISTRY:-}voicevault-worker:${VERSION:-latest}
+    pull_policy: missing
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST:-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB}
       - WORKER_MODE=download
@@ -78,6 +81,7 @@ services:
       context: ./worker
       dockerfile: Dockerfile
     image: ${REGISTRY:-}voicevault-worker:${VERSION:-latest}
+    pull_policy: missing
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST:-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB}
       - WORKER_MODE=asr

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -7,7 +7,8 @@ git clone https://github.com/your-username/voicevault.git
 cd voicevault
 cp .env.example .env
 # Edit .env — set GROQ_API_KEY (or configure an alternative provider)
-docker compose up --build
+# Uses published images from ghcr.io/nezhar by default; add --build to rebuild locally.
+docker compose up
 ```
 
 Services:
@@ -35,10 +36,21 @@ cp .env.example .env
 # - ACCESS_TOKEN → a secure random string
 ```
 
-### 3. Build and start
+### 3. Pull and start published images
+
+The production environment template points `REGISTRY` at the maintained GitHub Container Registry images and uses `VERSION=latest` by default:
+
+| Service | Image |
+|---------|-------|
+| Frontend | `ghcr.io/nezhar/voicevault-ui:latest` |
+| API | `ghcr.io/nezhar/voicevault-api:latest` |
+| Worker | `ghcr.io/nezhar/voicevault-worker:latest` |
+
+Pin `VERSION` to a release tag such as `0.4.0` when you need repeatable deployments.
 
 ```bash
-docker compose -f compose.prod.yml up -d --build
+docker compose -f compose.prod.yml pull
+docker compose -f compose.prod.yml up -d
 ```
 
 Check status:
@@ -47,9 +59,9 @@ docker compose -f compose.prod.yml ps
 curl http://your-server:8000/health
 ```
 
-### Using a Container Registry
+### Building and publishing custom images
 
-Build locally and deploy to a server:
+Use this only when you need your own registry or modified images. Override `REGISTRY` and `VERSION`, build the images, then push and deploy them:
 
 ```bash
 # On build machine

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -207,10 +207,14 @@ CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
 #!/bin/bash
 # deployment/vultr/deploy.sh
 
-# Build and push Docker image
-docker build -t voicevault-api .
-docker tag voicevault-api registry.vultr.com/voicevault/api:latest
-docker push registry.vultr.com/voicevault/api:latest
+# Pull the current published VoiceVault images
+docker pull ghcr.io/nezhar/voicevault-api:latest
+docker pull ghcr.io/nezhar/voicevault-ui:latest
+docker pull ghcr.io/nezhar/voicevault-worker:latest
+
+# Optional: mirror the API image into a private Vultr registry
+docker tag ghcr.io/nezhar/voicevault-api:latest registry.vultr.com/voicevault/voicevault-api:latest
+docker push registry.vultr.com/voicevault/voicevault-api:latest
 
 # Deploy to Vultr Kubernetes
 kubectl apply -f deployment/vultr/kubernetes/


### PR DESCRIPTION
### Motivation
- Make it easier to run VoiceVault by default by pointing environment templates and docs at the maintained GitHub Container Registry images. 
- Encourage reproducible production deployments by recommending pulling published images and explaining how to pin `VERSION`. 
- Ensure Compose will fetch missing published images while preserving local build contexts.

### Description
- Set `REGISTRY=ghcr.io/nezhar/` and add explanatory comments in `.env.example` and `.env.production` to reference the maintained GHCR images. 
- Update `README.md` and `docs/deployment.md` to recommend `docker compose up` (using published images), add a table listing `ghcr.io/nezhar/voicevault-ui`, `ghcr.io/nezhar/voicevault-api`, and `ghcr.io/nezhar/voicevault-worker`, and change production usage to `docker compose -f compose.prod.yml pull && docker compose -f compose.prod.yml up -d`. 
- Add `pull_policy: missing` to image entries in `compose.yml` and `compose.prod.yml` so Compose pulls registry images when they are not available locally while keeping existing `build` contexts. 
- Update `docs/implementation.md` (Vultr example) to `docker pull` the published images and include an optional mirroring step for a private registry.

### Testing
- Ran `git diff --check` which completed with no reported issues. 
- Attempted `docker compose config` / `docker compose -f compose.prod.yml config` but the Docker CLI was unavailable in the environment, so Compose validation was not executed. 
- Verified file diffs locally to confirm the intended documentation and Compose changes were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d79a6c328832992db5ba438d39905)