### PR TITLE
Project permalinks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,6 +359,10 @@ Optional Bearer token authentication (`/api/app/api/routes/auth.py`):
 - `POST /api/projects/{id}/members` - Add member by email (owner only)
 - `PUT|DELETE /api/projects/{id}/members/{user_id}` - Manage members / leave
 - `PUT /api/entries/{id}/project` - Move entry into/out of a project
+- `GET /api/projects/{id}/preview` - Permalink landing data (name, owners, your access state)
+- `POST|DELETE /api/projects/{id}/access-requests[/{rid}]` - Request or cancel access (OIDC mode)
+- `GET /api/projects/{id}/access-requests` - Owner: list requests (`?status=pending|approved|denied|all`)
+- `POST /api/projects/{id}/access-requests/{rid}/approve|deny` - Owner: decide, with a role
 - `GET /api/auth/config|me`, `POST /api/auth/logout`, `GET /api/auth/oidc/login|callback`
 
 ### System

--- a/api/app/api/routes/auth.py
+++ b/api/app/api/routes/auth.py
@@ -97,9 +97,33 @@ async def logout(request: Request, db: Session = Depends(get_db)):
     return response
 
 
+_REDIRECT_SESSION_KEY = "post_login_redirect"
+_MAX_NEXT_LENGTH = 512
+
+
+def safe_next_path(value: str | None) -> str:
+    """Only same-origin absolute paths survive.
+
+    Everything else — scheme-relative //host, absolute URLs, javascript:,
+    backslash variants — collapses to "/" so this cannot become an open
+    redirect off the back of the login flow.
+    """
+
+    if not value or len(value) > _MAX_NEXT_LENGTH:
+        return "/"
+    if not value.startswith("/") or value.startswith("//"):
+        return "/"
+    if "\\" in value:
+        return "/"
+    return value
+
+
 @router.get("/oidc/login")
-async def oidc_login(request: Request):
+async def oidc_login(request: Request, next: str | None = None):
     require_oidc_mode()
+    # Stored server-side rather than round-tripped through the IdP, so the
+    # target cannot be tampered with between the two requests.
+    request.session[_REDIRECT_SESSION_KEY] = safe_next_path(next)
     oauth = get_oauth()
     return await oauth.oidc.authorize_redirect(request, redirect_uri())
 
@@ -158,7 +182,8 @@ async def oidc_callback(request: Request, db: Session = Depends(get_db)):
 
     _, session_token = SessionService(db).create_session(user.id)
 
-    response = RedirectResponse(url="/", status_code=302)
+    target = safe_next_path(request.session.pop(_REDIRECT_SESSION_KEY, None))
+    response = RedirectResponse(url=target, status_code=302)
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=session_token,

--- a/api/app/api/routes/auth.py
+++ b/api/app/api/routes/auth.py
@@ -7,8 +7,8 @@ from sqlalchemy.orm import Session
 
 from authlib.integrations.base_client.errors import MismatchingStateError, OAuthError
 
-from app.core.auth import get_current_user, verify_access_token
-from app.core.config import AuthMode, settings
+from app.core.auth import get_current_user, require_oidc_mode, verify_access_token
+from app.core.config import settings
 from app.db.database import get_db
 from app.models.schemas import AuthConfigResponse, UserResponse
 from app.models.user import User
@@ -97,14 +97,9 @@ async def logout(request: Request, db: Session = Depends(get_db)):
     return response
 
 
-def _require_oidc_mode() -> None:
-    if settings.effective_auth_mode != AuthMode.OIDC:
-        raise HTTPException(status_code=404, detail="Not found")
-
-
 @router.get("/oidc/login")
 async def oidc_login(request: Request):
-    _require_oidc_mode()
+    require_oidc_mode()
     oauth = get_oauth()
     return await oauth.oidc.authorize_redirect(request, redirect_uri())
 
@@ -115,7 +110,7 @@ def _error_redirect(code: str) -> RedirectResponse:
 
 @router.get("/oidc/callback")
 async def oidc_callback(request: Request, db: Session = Depends(get_db)):
-    _require_oidc_mode()
+    require_oidc_mode()
     oauth = get_oauth()
 
     try:

--- a/api/app/api/routes/projects.py
+++ b/api/app/api/routes/projects.py
@@ -1,29 +1,39 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from app.core.auth import get_current_user
+from app.core.auth import get_current_user, require_oidc_mode
+from app.core.config import AuthMode, settings
 from app.db.database import get_db
 from app.models.entry import Entry
-from app.models.project import ProjectMember, ProjectRole
+from app.models.project import AccessRequestStatus, ProjectMember, ProjectRole
 from app.models.schemas import (
+    AccessRequestCreate,
+    AccessRequestDecision,
+    AccessRequestResponse,
     ProjectCreate,
     ProjectDetailResponse,
     ProjectMemberAdd,
     ProjectMemberResponse,
     ProjectMemberUpdate,
+    ProjectOwnerResponse,
+    ProjectPreviewResponse,
     ProjectResponse,
     ProjectUpdate,
 )
 from app.models.user import User
+from app.services.access_request_service import (
+    AccessRequestService,
+    AlreadyMemberError,
+)
 from app.services.authz import get_membership, require_project_role
 from app.services.project_service import LastOwnerError, ProjectService
 
 router = APIRouter()
 
 
-def _project_response(item: dict) -> ProjectResponse:
+def _project_response(item: dict, pending_request_count: int = 0) -> ProjectResponse:
     project = item["project"]
     return ProjectResponse(
         id=project.id,
@@ -35,6 +45,7 @@ def _project_response(item: dict) -> ProjectResponse:
         my_role=item["role"],
         member_count=item["member_count"],
         entry_count=item["entry_count"],
+        pending_request_count=pending_request_count,
     )
 
 
@@ -78,9 +89,13 @@ async def list_projects(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    items = ProjectService(db).list_for_user(current_user)
+    owned_ids = [
+        item["project"].id for item in items if item["role"] == ProjectRole.OWNER
+    ]
+    counts = AccessRequestService(db).pending_counts(owned_ids)
     return [
-        _project_response(item)
-        for item in ProjectService(db).list_for_user(current_user)
+        _project_response(item, counts.get(item["project"].id, 0)) for item in items
     ]
 
 
@@ -100,6 +115,11 @@ async def get_project(
         db.query(ProjectMember).filter(ProjectMember.project_id == project.id).all()
     )
     entry_count = db.query(Entry).filter(Entry.project_id == project.id).count()
+    pending_count = (
+        AccessRequestService(db).pending_counts([project.id]).get(project.id, 0)
+        if membership.role == ProjectRole.OWNER
+        else 0
+    )
     return ProjectDetailResponse(
         id=project.id,
         name=project.name,
@@ -110,6 +130,7 @@ async def get_project(
         my_role=membership.role,
         member_count=len(members),
         entry_count=entry_count,
+        pending_request_count=pending_count,
         members=[
             ProjectMemberResponse(
                 user_id=member.user_id,
@@ -119,6 +140,41 @@ async def get_project(
             )
             for member in members
         ],
+    )
+
+
+@router.get("/{project_id}/preview", response_model=ProjectPreviewResponse)
+async def preview_project(
+    project_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Permalink landing data. Unlike GET /{id}, this does not 404 for
+    non-members — revealing name and owners to whoever holds the UUID is the
+    whole point of a shareable link."""
+
+    try:
+        preview = AccessRequestService(db).preview(project_id, current_user)
+    except LookupError:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    request = preview["request"]
+    return ProjectPreviewResponse(
+        id=preview["project"].id,
+        name=preview["project"].name,
+        owners=[
+            ProjectOwnerResponse(
+                display_name=owner.display_name,
+                email=owner.email,
+            )
+            for owner in preview["owners"]
+        ],
+        my_role=preview["role"],
+        request_status=request.status if request else None,
+        request_id=request.id if request else None,
+        can_request=(
+            settings.effective_auth_mode == AuthMode.OIDC and preview["role"] is None
+        ),
     )
 
 
@@ -247,3 +303,147 @@ async def remove_member(
     except LastOwnerError as exc:
         raise HTTPException(status_code=409, detail=str(exc))
     return {"message": "Member removed"}
+
+
+def _access_request_response(request) -> AccessRequestResponse:
+    return AccessRequestResponse(
+        id=request.id,
+        project_id=request.project_id,
+        user_id=request.user_id,
+        email=request.user.email,
+        display_name=request.user.display_name,
+        status=request.status,
+        message=request.message,
+        created_at=request.created_at,
+        decided_at=request.decided_at,
+        decided_by_name=request.decider.display_name if request.decider else None,
+    )
+
+
+@router.post("/{project_id}/access-requests", response_model=AccessRequestResponse)
+async def request_access(
+    project_id: UUID,
+    data: AccessRequestCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    require_oidc_mode()
+    project = ProjectService(db).get_project(project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    try:
+        request = AccessRequestService(db).create_or_reopen(
+            project,
+            current_user,
+            data.message,
+        )
+    except AlreadyMemberError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    return _access_request_response(request)
+
+
+@router.delete("/{project_id}/access-requests/{request_id}")
+async def cancel_access_request(
+    project_id: UUID,
+    request_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    # cancel() checks that the request belongs to the caller, so a stranger
+    # passing someone else's id gets the same 404 as an unknown one.
+    require_oidc_mode()
+    try:
+        AccessRequestService(db).cancel(project_id, request_id, current_user)
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    return {"message": "Access request cancelled"}
+
+
+def _parse_status_filter(status: str) -> AccessRequestStatus | None:
+    if status == "all":
+        return None
+    try:
+        return AccessRequestStatus(status)
+    except ValueError:
+        raise HTTPException(status_code=422, detail="Unknown status filter")
+
+
+@router.get(
+    "/{project_id}/access-requests",
+    response_model=list[AccessRequestResponse],
+)
+async def list_access_requests(
+    project_id: UUID,
+    status: str = Query("pending"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    require_oidc_mode()
+    _, project, _ = _load_project_and_membership(
+        db,
+        project_id,
+        current_user,
+        ProjectRole.OWNER,
+    )
+    requests = AccessRequestService(db).list_for_project(
+        project,
+        _parse_status_filter(status),
+    )
+    return [_access_request_response(request) for request in requests]
+
+
+@router.post(
+    "/{project_id}/access-requests/{request_id}/approve",
+    response_model=AccessRequestResponse,
+)
+async def approve_access_request(
+    project_id: UUID,
+    request_id: UUID,
+    data: AccessRequestDecision,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    require_oidc_mode()
+    _, project, _ = _load_project_and_membership(
+        db,
+        project_id,
+        current_user,
+        ProjectRole.OWNER,
+    )
+    try:
+        request = AccessRequestService(db).approve(
+            project,
+            request_id,
+            current_user,
+            data.role,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return _access_request_response(request)
+
+
+@router.post(
+    "/{project_id}/access-requests/{request_id}/deny",
+    response_model=AccessRequestResponse,
+)
+async def deny_access_request(
+    project_id: UUID,
+    request_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    require_oidc_mode()
+    _, project, _ = _load_project_and_membership(
+        db,
+        project_id,
+        current_user,
+        ProjectRole.OWNER,
+    )
+    try:
+        request = AccessRequestService(db).deny(project, request_id, current_user)
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return _access_request_response(request)

--- a/api/app/core/auth.py
+++ b/api/app/core/auth.py
@@ -28,6 +28,17 @@ def verify_access_token(provided: str) -> bool:
     )
 
 
+def require_oidc_mode() -> None:
+    """404 outside OIDC mode.
+
+    The none and token modes share a single local user, so per-user features
+    like access requests have no meaning there — and 404 leaks less than 403.
+    """
+
+    if settings.effective_auth_mode != AuthMode.OIDC:
+        raise HTTPException(status_code=404, detail="Not found")
+
+
 def get_current_user(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Security(security),

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -1,7 +1,13 @@
 from app.models.entry import Entry, EntryStatus, SourceType
 from app.models.user import User
 from app.models.auth_session import AuthSession
-from app.models.project import Project, ProjectMember, ProjectRole
+from app.models.project import (
+    AccessRequestStatus,
+    Project,
+    ProjectAccessRequest,
+    ProjectMember,
+    ProjectRole,
+)
 from app.models.prompt_template import PromptTemplate
 
 __all__ = [
@@ -10,7 +16,9 @@ __all__ = [
     "SourceType",
     "User",
     "AuthSession",
+    "AccessRequestStatus",
     "Project",
+    "ProjectAccessRequest",
     "ProjectMember",
     "ProjectRole",
     "PromptTemplate",

--- a/api/app/models/project.py
+++ b/api/app/models/project.py
@@ -1,4 +1,12 @@
-from sqlalchemy import Column, DateTime, Enum as SQLEnum, ForeignKey, String, Text
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Enum as SQLEnum,
+    ForeignKey,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from app.core.timeutils import utcnow
@@ -48,3 +56,52 @@ class ProjectMember(Base):
     added_at = Column(DateTime, default=utcnow)
 
     user = relationship("User", lazy="joined")
+
+
+class AccessRequestStatus(str, Enum):
+    PENDING = "pending"
+    APPROVED = "approved"
+    DENIED = "denied"
+
+
+class ProjectAccessRequest(Base):
+    """One row per (project, user). A denied user re-requesting resets this row
+    to pending rather than inserting a second one, so an owner's list can never
+    be flooded by one person."""
+
+    __tablename__ = "project_access_requests"
+    __table_args__ = (
+        UniqueConstraint(
+            "project_id",
+            "user_id",
+            name="uq_access_requests_project_user",
+        ),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    status = Column(
+        SQLEnum(AccessRequestStatus),
+        nullable=False,
+        default=AccessRequestStatus.PENDING,
+    )
+    message = Column(String(500), nullable=True)
+    created_at = Column(DateTime, default=utcnow)
+    updated_at = Column(DateTime, default=utcnow, onupdate=utcnow)
+    decided_by = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    decided_at = Column(DateTime, nullable=True)
+
+    # Two FKs point at users, so the join condition must be spelled out or
+    # SQLAlchemy raises AmbiguousForeignKeysError when mappers configure.
+    user = relationship("User", foreign_keys=[user_id], lazy="joined")
+    decider = relationship("User", foreign_keys=[decided_by], lazy="joined")

--- a/api/app/models/schemas.py
+++ b/api/app/models/schemas.py
@@ -5,7 +5,7 @@ from typing import Any
 from datetime import datetime
 from uuid import UUID
 from .entry import EntryStatus, SourceType
-from .project import ProjectRole
+from .project import AccessRequestStatus, ProjectRole
 
 
 def _normalize_language(value: Any) -> Any:
@@ -277,7 +277,47 @@ class ProjectResponse(BaseModel):
     my_role: ProjectRole
     member_count: int
     entry_count: int
+    # Only non-zero for owners; other roles never see the badge.
+    pending_request_count: int = 0
 
 
 class ProjectDetailResponse(ProjectResponse):
     members: list[ProjectMemberResponse]
+
+
+class ProjectOwnerResponse(BaseModel):
+    display_name: str
+    email: str
+
+
+class ProjectPreviewResponse(BaseModel):
+    """Everything a permalink reveals to someone who is not a member."""
+
+    id: UUID
+    name: str
+    owners: list[ProjectOwnerResponse]
+    my_role: ProjectRole | None = None
+    request_status: AccessRequestStatus | None = None
+    request_id: UUID | None = None
+    can_request: bool = False
+
+
+class AccessRequestCreate(BaseModel):
+    message: str | None = Field(default=None, max_length=500)
+
+
+class AccessRequestDecision(BaseModel):
+    role: ProjectRole = ProjectRole.VIEWER
+
+
+class AccessRequestResponse(BaseModel):
+    id: UUID
+    project_id: UUID
+    user_id: UUID
+    email: str
+    display_name: str
+    status: AccessRequestStatus
+    message: str | None = None
+    created_at: datetime
+    decided_at: datetime | None = None
+    decided_by_name: str | None = None

--- a/api/app/services/access_request_service.py
+++ b/api/app/services/access_request_service.py
@@ -1,0 +1,199 @@
+from uuid import UUID
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.core.timeutils import utcnow
+from app.models.project import (
+    AccessRequestStatus,
+    Project,
+    ProjectAccessRequest,
+    ProjectMember,
+    ProjectRole,
+)
+from app.models.user import User
+from app.services.authz import get_membership
+
+
+class AlreadyMemberError(Exception):
+    """The requesting user already belongs to the project."""
+
+
+class AccessRequestService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get_request(
+        self,
+        project_id: UUID,
+        request_id: UUID,
+    ) -> ProjectAccessRequest | None:
+        return (
+            self.db.query(ProjectAccessRequest)
+            .filter(
+                ProjectAccessRequest.id == request_id,
+                ProjectAccessRequest.project_id == project_id,
+            )
+            .first()
+        )
+
+    def get_for_user(
+        self,
+        project_id: UUID,
+        user_id: UUID,
+    ) -> ProjectAccessRequest | None:
+        return (
+            self.db.query(ProjectAccessRequest)
+            .filter(
+                ProjectAccessRequest.project_id == project_id,
+                ProjectAccessRequest.user_id == user_id,
+            )
+            .first()
+        )
+
+    def create_or_reopen(
+        self,
+        project: Project,
+        user: User,
+        message: str | None,
+    ) -> ProjectAccessRequest:
+        if get_membership(self.db, project.id, user.id) is not None:
+            raise AlreadyMemberError("You are already a member of this project.")
+
+        existing = self.get_for_user(project.id, user.id)
+        if existing is not None:
+            existing.status = AccessRequestStatus.PENDING
+            existing.message = message
+            existing.decided_by = None
+            existing.decided_at = None
+            self.db.commit()
+            return existing
+
+        request = ProjectAccessRequest(
+            project_id=project.id,
+            user_id=user.id,
+            status=AccessRequestStatus.PENDING,
+            message=message,
+        )
+        self.db.add(request)
+        self.db.commit()
+        return request
+
+    def cancel(self, project_id: UUID, request_id: UUID, user: User) -> None:
+        request = self.get_request(project_id, request_id)
+        if request is None or request.user_id != user.id:
+            raise LookupError("Access request not found.")
+        if request.status != AccessRequestStatus.PENDING:
+            raise ValueError("Only a pending request can be cancelled.")
+
+        self.db.delete(request)
+        self.db.commit()
+
+    def list_for_project(
+        self,
+        project: Project,
+        status: AccessRequestStatus | None = AccessRequestStatus.PENDING,
+    ) -> list[ProjectAccessRequest]:
+        query = self.db.query(ProjectAccessRequest).filter(
+            ProjectAccessRequest.project_id == project.id,
+        )
+        if status is not None:
+            query = query.filter(ProjectAccessRequest.status == status)
+        return query.order_by(ProjectAccessRequest.created_at.desc()).all()
+
+    def approve(
+        self,
+        project: Project,
+        request_id: UUID,
+        decider: User,
+        role: ProjectRole = ProjectRole.VIEWER,
+    ) -> ProjectAccessRequest:
+        """Grant membership and settle the request in one transaction.
+
+        Idempotent on purpose: two owners clicking Approve at the same moment
+        should end with a settled request, not a 500.
+        """
+
+        request = self.get_request(project.id, request_id)
+        if request is None:
+            raise LookupError("Access request not found.")
+        if request.status == AccessRequestStatus.APPROVED:
+            return request
+
+        if get_membership(self.db, project.id, request.user_id) is None:
+            self.db.add(
+                ProjectMember(
+                    project_id=project.id,
+                    user_id=request.user_id,
+                    role=role,
+                ),
+            )
+
+        request.status = AccessRequestStatus.APPROVED
+        request.decided_by = decider.id
+        request.decided_at = utcnow()
+        self.db.commit()
+        return request
+
+    def deny(
+        self,
+        project: Project,
+        request_id: UUID,
+        decider: User,
+    ) -> ProjectAccessRequest:
+        request = self.get_request(project.id, request_id)
+        if request is None:
+            raise LookupError("Access request not found.")
+        if request.status == AccessRequestStatus.DENIED:
+            return request
+
+        request.status = AccessRequestStatus.DENIED
+        request.decided_by = decider.id
+        request.decided_at = utcnow()
+        self.db.commit()
+        return request
+
+    def pending_counts(self, project_ids: list[UUID]) -> dict[UUID, int]:
+        """One grouped query for every project, so the sidebar badge costs
+        nothing per project."""
+
+        if not project_ids:
+            return {}
+
+        rows = (
+            self.db.query(
+                ProjectAccessRequest.project_id,
+                func.count(ProjectAccessRequest.id),
+            )
+            .filter(
+                ProjectAccessRequest.project_id.in_(project_ids),
+                ProjectAccessRequest.status == AccessRequestStatus.PENDING,
+            )
+            .group_by(ProjectAccessRequest.project_id)
+            .all()
+        )
+        return dict(rows)
+
+    def preview(self, project_id: UUID, user: User) -> dict:
+        """Minimal disclosure for a permalink: name, owners, and where the
+        caller stands. Deliberately does not expose description or counts."""
+
+        project = self.db.query(Project).filter(Project.id == project_id).first()
+        if project is None:
+            raise LookupError("Project not found.")
+
+        owners = (
+            self.db.query(ProjectMember)
+            .filter(
+                ProjectMember.project_id == project.id,
+                ProjectMember.role == ProjectRole.OWNER,
+            )
+            .all()
+        )
+        membership = get_membership(self.db, project.id, user.id)
+        return {
+            "project": project,
+            "owners": [member.user for member in owners],
+            "role": membership.role if membership else None,
+            "request": self.get_for_user(project.id, user.id),
+        }

--- a/api/tests/test_access_request_service.py
+++ b/api/tests/test_access_request_service.py
@@ -1,0 +1,343 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.models.project import AccessRequestStatus, ProjectAccessRequest, ProjectRole
+from app.services import access_request_service as service_module
+from app.services.access_request_service import (
+    AccessRequestService,
+    AlreadyMemberError,
+)
+
+
+def make_user(user_id=None):
+    return SimpleNamespace(id=user_id or uuid4())
+
+
+def make_project(project_id=None):
+    return SimpleNamespace(id=project_id or uuid4(), name="Team Alpha")
+
+
+def existing_request(user_id, status=AccessRequestStatus.PENDING):
+    return SimpleNamespace(
+        id=uuid4(),
+        user_id=user_id,
+        status=status,
+        message=None,
+        decided_by=uuid4(),
+        decided_at="2026-01-01",
+    )
+
+
+class ModelShapeTests(TestCase):
+    def test_table_name_and_unique_constraint(self):
+        self.assertEqual(ProjectAccessRequest.__tablename__, "project_access_requests")
+        constraint_columns = {
+            tuple(sorted(column.name for column in constraint.columns))
+            for constraint in ProjectAccessRequest.__table__.constraints
+            if constraint.__class__.__name__ == "UniqueConstraint"
+        }
+        self.assertIn(("project_id", "user_id"), constraint_columns)
+
+    def test_status_values(self):
+        self.assertEqual(AccessRequestStatus.PENDING, "pending")
+        self.assertEqual(AccessRequestStatus.APPROVED, "approved")
+        self.assertEqual(AccessRequestStatus.DENIED, "denied")
+
+    def test_new_request_defaults_to_pending(self):
+        column = ProjectAccessRequest.__table__.columns["status"]
+        self.assertEqual(column.default.arg, AccessRequestStatus.PENDING)
+        self.assertFalse(column.nullable)
+
+
+class CreateRequestTests(TestCase):
+    @patch.object(service_module, "get_membership", return_value=None)
+    def test_first_request_is_added_as_pending(self, _membership):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+        user = make_user()
+        project = make_project()
+
+        request = AccessRequestService(db).create_or_reopen(project, user, "let me in")
+
+        self.assertIsInstance(request, ProjectAccessRequest)
+        self.assertEqual(request.project_id, project.id)
+        self.assertEqual(request.user_id, user.id)
+        self.assertEqual(request.message, "let me in")
+        db.add.assert_called_once()
+        db.commit.assert_called_once()
+
+    @patch.object(service_module, "get_membership", return_value=None)
+    def test_denied_request_reopens_the_same_row(self, _membership):
+        user = make_user()
+        stored = existing_request(user.id, AccessRequestStatus.DENIED)
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = stored
+
+        request = AccessRequestService(db).create_or_reopen(
+            make_project(),
+            user,
+            "trying again",
+        )
+
+        self.assertIs(request, stored)
+        self.assertEqual(request.status, AccessRequestStatus.PENDING)
+        self.assertEqual(request.message, "trying again")
+        self.assertIsNone(request.decided_by)
+        self.assertIsNone(request.decided_at)
+        db.add.assert_not_called()
+        db.commit.assert_called_once()
+
+    @patch.object(
+        service_module,
+        "get_membership",
+        return_value=SimpleNamespace(role=ProjectRole.VIEWER),
+    )
+    def test_member_cannot_request_access(self, _membership):
+        db = MagicMock()
+
+        with self.assertRaises(AlreadyMemberError):
+            AccessRequestService(db).create_or_reopen(make_project(), make_user(), None)
+
+        db.commit.assert_not_called()
+
+
+class CancelRequestTests(TestCase):
+    def test_requester_cancels_own_pending_request(self):
+        user = make_user()
+        stored = existing_request(user.id)
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = stored
+        project = make_project()
+
+        AccessRequestService(db).cancel(project.id, stored.id, user)
+
+        db.delete.assert_called_once_with(stored)
+        db.commit.assert_called_once()
+
+    def test_cannot_cancel_someone_elses_request(self):
+        stored = existing_request(uuid4())
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = stored
+
+        with self.assertRaises(LookupError):
+            AccessRequestService(db).cancel(uuid4(), stored.id, make_user())
+
+        db.delete.assert_not_called()
+
+    def test_cannot_cancel_a_decided_request(self):
+        user = make_user()
+        stored = existing_request(user.id, AccessRequestStatus.APPROVED)
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = stored
+
+        with self.assertRaises(ValueError):
+            AccessRequestService(db).cancel(uuid4(), stored.id, user)
+
+        db.delete.assert_not_called()
+
+
+class ApproveTests(TestCase):
+    @patch.object(service_module, "get_membership", return_value=None)
+    def test_approve_creates_member_with_selected_role(self, _membership):
+        requester_id = uuid4()
+        stored = existing_request(requester_id)
+        stored.status = AccessRequestStatus.PENDING
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = stored
+        project = make_project()
+        decider = make_user()
+
+        request = AccessRequestService(db).approve(
+            project,
+            stored.id,
+            decider,
+            ProjectRole.EDITOR,
+        )
+
+        member = db.add.call_args.args[0]
+        self.assertEqual(type(member).__name__, "ProjectMember")
+        self.assertEqual(member.project_id, project.id)
+        self.assertEqual(member.user_id, requester_id)
+        self.assertEqual(member.role, ProjectRole.EDITOR)
+        self.assertEqual(request.status, AccessRequestStatus.APPROVED)
+        self.assertEqual(request.decided_by, decider.id)
+        self.assertIsNotNone(request.decided_at)
+        db.commit.assert_called_once()
+
+    @patch.object(
+        service_module,
+        "get_membership",
+        return_value=SimpleNamespace(role=ProjectRole.VIEWER),
+    )
+    def test_approve_does_not_duplicate_an_existing_member(self, _membership):
+        stored = existing_request(uuid4())
+        stored.status = AccessRequestStatus.PENDING
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = stored
+
+        request = AccessRequestService(db).approve(
+            make_project(),
+            stored.id,
+            make_user(),
+            ProjectRole.VIEWER,
+        )
+
+        db.add.assert_not_called()
+        self.assertEqual(request.status, AccessRequestStatus.APPROVED)
+
+    @patch.object(service_module, "get_membership", return_value=None)
+    def test_approving_twice_is_a_no_op(self, _membership):
+        stored = existing_request(uuid4(), AccessRequestStatus.APPROVED)
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = stored
+
+        request = AccessRequestService(db).approve(
+            make_project(),
+            stored.id,
+            make_user(),
+            ProjectRole.OWNER,
+        )
+
+        self.assertEqual(request.status, AccessRequestStatus.APPROVED)
+        db.add.assert_not_called()
+        db.commit.assert_not_called()
+
+    def test_unknown_request_raises_lookup_error(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+
+        with self.assertRaises(LookupError):
+            AccessRequestService(db).approve(
+                make_project(),
+                uuid4(),
+                make_user(),
+                ProjectRole.VIEWER,
+            )
+
+
+class DenyTests(TestCase):
+    def test_deny_keeps_the_row_and_records_the_decider(self):
+        stored = existing_request(uuid4())
+        stored.status = AccessRequestStatus.PENDING
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = stored
+        decider = make_user()
+
+        request = AccessRequestService(db).deny(make_project(), stored.id, decider)
+
+        self.assertEqual(request.status, AccessRequestStatus.DENIED)
+        self.assertEqual(request.decided_by, decider.id)
+        self.assertIsNotNone(request.decided_at)
+        db.delete.assert_not_called()
+        db.commit.assert_called_once()
+
+    def test_denying_twice_is_a_no_op(self):
+        stored = existing_request(uuid4(), AccessRequestStatus.DENIED)
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = stored
+
+        AccessRequestService(db).deny(make_project(), stored.id, make_user())
+
+        db.commit.assert_not_called()
+
+
+class ListRequestsTests(TestCase):
+    def test_defaults_to_pending_only(self):
+        db = MagicMock()
+        chain = db.query.return_value.filter.return_value
+        chain.filter.return_value.order_by.return_value.all.return_value = ["row"]
+
+        result = AccessRequestService(db).list_for_project(make_project())
+
+        self.assertEqual(result, ["row"])
+        chain.filter.assert_called_once()
+
+    def test_status_none_returns_every_request(self):
+        db = MagicMock()
+        chain = db.query.return_value.filter.return_value
+        chain.order_by.return_value.all.return_value = ["a", "b"]
+
+        result = AccessRequestService(db).list_for_project(make_project(), status=None)
+
+        self.assertEqual(result, ["a", "b"])
+        chain.filter.assert_not_called()
+
+
+class PreviewTests(TestCase):
+    def _db_with(self, project, owners, request):
+        """query(Project) -> project, query(ProjectMember) -> owners,
+        query(ProjectAccessRequest) -> request."""
+
+        db = MagicMock()
+
+        def query(model):
+            result = MagicMock()
+            name = getattr(model, "__name__", "")
+            if name == "Project":
+                result.filter.return_value.first.return_value = project
+            elif name == "ProjectMember":
+                result.filter.return_value.all.return_value = owners
+            else:
+                result.filter.return_value.first.return_value = request
+            return result
+
+        db.query.side_effect = query
+        return db
+
+    @patch.object(service_module, "get_membership", return_value=None)
+    def test_non_member_sees_project_and_owners(self, _membership):
+        project = make_project()
+        owner_user = SimpleNamespace(display_name="Ada", email="ada@corp")
+        owners = [SimpleNamespace(user=owner_user)]
+        db = self._db_with(project, owners, None)
+
+        preview = AccessRequestService(db).preview(project.id, make_user())
+
+        self.assertIs(preview["project"], project)
+        self.assertEqual(preview["owners"], [owner_user])
+        self.assertIsNone(preview["role"])
+        self.assertIsNone(preview["request"])
+
+    @patch.object(
+        service_module,
+        "get_membership",
+        return_value=SimpleNamespace(role=ProjectRole.EDITOR),
+    )
+    def test_member_preview_reports_their_role(self, _membership):
+        project = make_project()
+        db = self._db_with(project, [], None)
+
+        preview = AccessRequestService(db).preview(project.id, make_user())
+
+        self.assertEqual(preview["role"], ProjectRole.EDITOR)
+
+    def test_unknown_project_raises_lookup_error(self):
+        db = self._db_with(None, [], None)
+
+        with self.assertRaises(LookupError):
+            AccessRequestService(db).preview(uuid4(), make_user())
+
+
+class PendingCountTests(TestCase):
+    def test_empty_input_skips_the_query(self):
+        db = MagicMock()
+
+        self.assertEqual(AccessRequestService(db).pending_counts([]), {})
+
+        db.query.assert_not_called()
+
+    def test_groups_counts_by_project(self):
+        first, second = uuid4(), uuid4()
+        db = MagicMock()
+        chain = db.query.return_value.filter.return_value.group_by.return_value
+        chain.all.return_value = [(first, 2), (second, 1)]
+
+        counts = AccessRequestService(db).pending_counts([first, second])
+
+        self.assertEqual(counts, {first: 2, second: 1})

--- a/api/tests/test_auth_modes.py
+++ b/api/tests/test_auth_modes.py
@@ -99,3 +99,16 @@ class OidcModeTests(TestCase):
         result = auth_module.get_current_user(request, None, db)
 
         self.assertIs(result, user)
+
+
+class RequireOidcModeTests(TestCase):
+    @patch.object(auth_module.settings, "auth_mode", AuthMode.OIDC)
+    def test_passes_in_oidc_mode(self):
+        auth_module.require_oidc_mode()  # must not raise
+
+    @patch.object(auth_module.settings, "auth_mode", AuthMode.TOKEN)
+    @patch.object(auth_module.settings, "access_token", "secret")
+    def test_hides_the_route_in_other_modes(self):
+        with self.assertRaises(HTTPException) as ctx:
+            auth_module.require_oidc_mode()
+        self.assertEqual(ctx.exception.status_code, 404)

--- a/api/tests/test_auth_routes.py
+++ b/api/tests/test_auth_routes.py
@@ -1,7 +1,7 @@
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from unittest import IsolatedAsyncioTestCase
+from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -20,7 +20,7 @@ class AuthConfigTests(IsolatedAsyncioTestCase):
 
 class OidcCallbackTests(IsolatedAsyncioTestCase):
     def _request(self):
-        return SimpleNamespace(cookies={})
+        return SimpleNamespace(cookies={}, session={})
 
     @patch.object(auth_routes.settings, "auth_mode", AuthMode.OIDC)
     @patch.object(auth_routes.settings, "initial_owner_email", "admin@corp")
@@ -132,3 +132,73 @@ class LogoutTests(IsolatedAsyncioTestCase):
 
         session_service_mock.return_value.delete_session.assert_called_once_with("abc")
         self.assertIn("voicevault_session=", response.headers["set-cookie"])
+
+
+class SafeNextPathTests(TestCase):
+    def test_accepts_an_internal_path(self):
+        self.assertEqual(
+            auth_routes.safe_next_path("/projects/8f3c"),
+            "/projects/8f3c",
+        )
+
+    def test_rejects_protocol_relative_url(self):
+        self.assertEqual(auth_routes.safe_next_path("//evil.example.com"), "/")
+
+    def test_rejects_absolute_url(self):
+        self.assertEqual(auth_routes.safe_next_path("https://evil.example.com"), "/")
+
+    def test_rejects_javascript_scheme(self):
+        self.assertEqual(auth_routes.safe_next_path("javascript:alert(1)"), "/")
+
+    def test_rejects_backslash_tricks(self):
+        self.assertEqual(auth_routes.safe_next_path("/\\evil.example.com"), "/")
+
+    def test_rejects_missing_leading_slash(self):
+        self.assertEqual(auth_routes.safe_next_path("projects/8f3c"), "/")
+
+    def test_rejects_overlong_value(self):
+        self.assertEqual(auth_routes.safe_next_path("/" + "a" * 512), "/")
+
+    def test_none_becomes_root(self):
+        self.assertEqual(auth_routes.safe_next_path(None), "/")
+
+
+class OidcRedirectTargetTests(IsolatedAsyncioTestCase):
+    def _request(self, session):
+        return SimpleNamespace(cookies={}, session=session)
+
+    @patch.object(auth_routes.settings, "auth_mode", AuthMode.OIDC)
+    @patch.object(auth_routes.settings, "initial_owner_email", "")
+    @patch.object(auth_routes.settings, "session_cookie_secure", False)
+    @patch("app.api.routes.auth.SessionService")
+    @patch("app.api.routes.auth.UserService")
+    @patch("app.api.routes.auth.get_oauth")
+    async def test_callback_redirects_to_the_stored_target(
+        self,
+        get_oauth_mock,
+        user_service_mock,
+        session_service_mock,
+    ):
+        get_oauth_mock.return_value.oidc.authorize_access_token = AsyncMock(
+            return_value={
+                "userinfo": {
+                    "iss": "https://idp.test",
+                    "sub": "u1",
+                    "email": "user@corp",
+                    "name": "User",
+                },
+            },
+        )
+        user_service_mock.return_value.provision_oidc_user.return_value = (
+            SimpleNamespace(id=uuid4(), email="user@corp", is_system=False)
+        )
+        session_service_mock.return_value.create_session.return_value = (
+            SimpleNamespace(id="hashed"),
+            "session-id",
+        )
+        session = {"post_login_redirect": "/projects/8f3c"}
+
+        response = await auth_routes.oidc_callback(self._request(session), MagicMock())
+
+        self.assertEqual(response.headers["location"], "/projects/8f3c")
+        self.assertNotIn("post_login_redirect", session)

--- a/api/tests/test_project_access_requests.py
+++ b/api/tests/test_project_access_requests.py
@@ -1,0 +1,499 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi import HTTPException
+
+from app.api.routes import projects as project_routes
+from app.core.config import AuthMode
+from app.models.project import AccessRequestStatus, ProjectRole
+from app.models.schemas import (
+    AccessRequestCreate,
+    AccessRequestDecision,
+    ProjectPreviewResponse,
+)
+from app.services.access_request_service import AlreadyMemberError
+
+
+def make_user(user_id=None):
+    return SimpleNamespace(id=user_id or uuid4(), email="me@corp", display_name="Me")
+
+
+def make_project(project_id=None):
+    return SimpleNamespace(id=project_id or uuid4(), name="Team Alpha")
+
+
+class SchemaTests(TestCase):
+    def test_decision_defaults_to_the_lowest_role(self):
+        self.assertEqual(AccessRequestDecision().role, ProjectRole.VIEWER)
+
+    def test_message_is_optional_and_length_capped(self):
+        self.assertIsNone(AccessRequestCreate().message)
+        with self.assertRaises(ValueError):
+            AccessRequestCreate(message="x" * 501)
+
+    def test_preview_allows_no_role_and_no_request(self):
+        preview = ProjectPreviewResponse(
+            id="11111111-1111-1111-1111-111111111111",
+            name="Team Alpha",
+            owners=[{"display_name": "Ada", "email": "ada@corp"}],
+            can_request=True,
+        )
+        self.assertIsNone(preview.my_role)
+        self.assertIsNone(preview.request_status)
+        self.assertIsNone(preview.request_id)
+
+    def test_preview_carries_request_state(self):
+        preview = ProjectPreviewResponse(
+            id="11111111-1111-1111-1111-111111111111",
+            name="Team Alpha",
+            owners=[],
+            my_role=ProjectRole.VIEWER,
+            request_status=AccessRequestStatus.PENDING,
+            request_id="22222222-2222-2222-2222-222222222222",
+            can_request=False,
+        )
+        self.assertEqual(preview.request_status, AccessRequestStatus.PENDING)
+
+
+class PreviewRouteTests(IsolatedAsyncioTestCase):
+    @patch.object(project_routes.settings, "auth_mode", AuthMode.OIDC)
+    @patch("app.api.routes.projects.AccessRequestService")
+    async def test_non_member_gets_name_owners_and_can_request(self, service_mock):
+        project = make_project()
+        service_mock.return_value.preview.return_value = {
+            "project": project,
+            "owners": [SimpleNamespace(display_name="Ada", email="ada@corp")],
+            "role": None,
+            "request": None,
+        }
+
+        result = await project_routes.preview_project(
+            project.id,
+            MagicMock(),
+            make_user(),
+        )
+
+        self.assertEqual(result.name, "Team Alpha")
+        self.assertEqual(result.owners[0].email, "ada@corp")
+        self.assertIsNone(result.my_role)
+        self.assertTrue(result.can_request)
+
+    @patch.object(project_routes.settings, "auth_mode", AuthMode.OIDC)
+    @patch("app.api.routes.projects.AccessRequestService")
+    async def test_member_cannot_request(self, service_mock):
+        project = make_project()
+        service_mock.return_value.preview.return_value = {
+            "project": project,
+            "owners": [],
+            "role": ProjectRole.VIEWER,
+            "request": None,
+        }
+
+        result = await project_routes.preview_project(
+            project.id,
+            MagicMock(),
+            make_user(),
+        )
+
+        self.assertEqual(result.my_role, ProjectRole.VIEWER)
+        self.assertFalse(result.can_request)
+
+    @patch.object(project_routes.settings, "auth_mode", AuthMode.TOKEN)
+    @patch.object(project_routes.settings, "access_token", "secret")
+    @patch("app.api.routes.projects.AccessRequestService")
+    async def test_outside_oidc_preview_works_but_forbids_requesting(
+        self,
+        service_mock,
+    ):
+        project = make_project()
+        service_mock.return_value.preview.return_value = {
+            "project": project,
+            "owners": [],
+            "role": None,
+            "request": None,
+        }
+
+        result = await project_routes.preview_project(
+            project.id,
+            MagicMock(),
+            make_user(),
+        )
+
+        self.assertFalse(result.can_request)
+
+    @patch.object(project_routes.settings, "auth_mode", AuthMode.OIDC)
+    @patch("app.api.routes.projects.AccessRequestService")
+    async def test_unknown_project_is_404(self, service_mock):
+        service_mock.return_value.preview.side_effect = LookupError("gone")
+
+        with self.assertRaises(HTTPException) as ctx:
+            await project_routes.preview_project(uuid4(), MagicMock(), make_user())
+
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    @patch.object(project_routes.settings, "auth_mode", AuthMode.OIDC)
+    @patch("app.api.routes.projects.AccessRequestService")
+    async def test_pending_request_is_reported_with_its_id(self, service_mock):
+        project = make_project()
+        request_id = uuid4()
+        service_mock.return_value.preview.return_value = {
+            "project": project,
+            "owners": [],
+            "role": None,
+            "request": SimpleNamespace(
+                id=request_id,
+                status=AccessRequestStatus.PENDING,
+            ),
+        }
+
+        result = await project_routes.preview_project(
+            project.id,
+            MagicMock(),
+            make_user(),
+        )
+
+        self.assertEqual(result.request_status, AccessRequestStatus.PENDING)
+        self.assertEqual(result.request_id, request_id)
+
+
+class ListProjectsBadgeTests(IsolatedAsyncioTestCase):
+    @patch("app.api.routes.projects.AccessRequestService")
+    @patch("app.api.routes.projects.ProjectService")
+    async def test_owner_projects_carry_pending_counts(
+        self,
+        project_service_mock,
+        request_service_mock,
+    ):
+        owned = make_project()
+        joined = make_project()
+        for project in (owned, joined):
+            project.description = None
+            project.created_by = uuid4()
+            project.created_at = "2026-01-01T00:00:00"
+            project.updated_at = "2026-01-01T00:00:00"
+
+        project_service_mock.return_value.list_for_user.return_value = [
+            {
+                "project": owned,
+                "role": ProjectRole.OWNER,
+                "member_count": 2,
+                "entry_count": 3,
+            },
+            {
+                "project": joined,
+                "role": ProjectRole.VIEWER,
+                "member_count": 5,
+                "entry_count": 1,
+            },
+        ]
+        request_service_mock.return_value.pending_counts.return_value = {owned.id: 4}
+
+        result = await project_routes.list_projects(MagicMock(), make_user())
+
+        self.assertEqual(result[0].pending_request_count, 4)
+        self.assertEqual(result[1].pending_request_count, 0)
+        request_service_mock.return_value.pending_counts.assert_called_once_with(
+            [owned.id],
+        )
+
+
+def stored_request(user, status=AccessRequestStatus.PENDING):
+    return SimpleNamespace(
+        id=uuid4(),
+        project_id=uuid4(),
+        user_id=user.id,
+        user=user,
+        status=status,
+        message="let me in",
+        created_at="2026-01-01T00:00:00",
+        decided_at=None,
+        decider=None,
+    )
+
+
+class RequestAccessRouteTests(IsolatedAsyncioTestCase):
+    @patch.object(project_routes.settings, "auth_mode", AuthMode.OIDC)
+    @patch("app.api.routes.projects.AccessRequestService")
+    @patch("app.api.routes.projects.ProjectService")
+    async def test_creates_a_request(self, project_service_mock, request_service_mock):
+        user = make_user()
+        project = make_project()
+        project_service_mock.return_value.get_project.return_value = project
+        request_service_mock.return_value.create_or_reopen.return_value = (
+            stored_request(user)
+        )
+
+        result = await project_routes.request_access(
+            project.id,
+            AccessRequestCreate(message="let me in"),
+            MagicMock(),
+            user,
+        )
+
+        self.assertEqual(result.status, AccessRequestStatus.PENDING)
+        self.assertEqual(result.message, "let me in")
+        request_service_mock.return_value.create_or_reopen.assert_called_once_with(
+            project,
+            user,
+            "let me in",
+        )
+
+    @patch.object(project_routes.settings, "auth_mode", AuthMode.OIDC)
+    @patch("app.api.routes.projects.AccessRequestService")
+    @patch("app.api.routes.projects.ProjectService")
+    async def test_member_gets_409(self, project_service_mock, request_service_mock):
+        project_service_mock.return_value.get_project.return_value = make_project()
+        request_service_mock.return_value.create_or_reopen.side_effect = (
+            AlreadyMemberError("already a member")
+        )
+
+        with self.assertRaises(HTTPException) as ctx:
+            await project_routes.request_access(
+                uuid4(),
+                AccessRequestCreate(),
+                MagicMock(),
+                make_user(),
+            )
+
+        self.assertEqual(ctx.exception.status_code, 409)
+
+    @patch.object(project_routes.settings, "auth_mode", AuthMode.OIDC)
+    @patch("app.api.routes.projects.ProjectService")
+    async def test_unknown_project_is_404(self, project_service_mock):
+        project_service_mock.return_value.get_project.return_value = None
+
+        with self.assertRaises(HTTPException) as ctx:
+            await project_routes.request_access(
+                uuid4(),
+                AccessRequestCreate(),
+                MagicMock(),
+                make_user(),
+            )
+
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    @patch.object(project_routes.settings, "auth_mode", AuthMode.TOKEN)
+    @patch.object(project_routes.settings, "access_token", "secret")
+    async def test_hidden_outside_oidc_mode(self):
+        with self.assertRaises(HTTPException) as ctx:
+            await project_routes.request_access(
+                uuid4(),
+                AccessRequestCreate(),
+                MagicMock(),
+                make_user(),
+            )
+
+        self.assertEqual(ctx.exception.status_code, 404)
+
+
+class CancelRequestRouteTests(IsolatedAsyncioTestCase):
+    @patch.object(project_routes.settings, "auth_mode", AuthMode.OIDC)
+    @patch("app.api.routes.projects.AccessRequestService")
+    async def test_cancels_own_request(self, request_service_mock):
+        project_id, request_id = uuid4(), uuid4()
+        user = make_user()
+
+        result = await project_routes.cancel_access_request(
+            project_id,
+            request_id,
+            MagicMock(),
+            user,
+        )
+
+        self.assertEqual(result, {"message": "Access request cancelled"})
+        request_service_mock.return_value.cancel.assert_called_once_with(
+            project_id,
+            request_id,
+            user,
+        )
+
+    @patch.object(project_routes.settings, "auth_mode", AuthMode.OIDC)
+    @patch("app.api.routes.projects.AccessRequestService")
+    async def test_someone_elses_request_is_404(self, request_service_mock):
+        request_service_mock.return_value.cancel.side_effect = LookupError("nope")
+
+        with self.assertRaises(HTTPException) as ctx:
+            await project_routes.cancel_access_request(
+                uuid4(),
+                uuid4(),
+                MagicMock(),
+                make_user(),
+            )
+
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    @patch.object(project_routes.settings, "auth_mode", AuthMode.OIDC)
+    @patch("app.api.routes.projects.AccessRequestService")
+    async def test_decided_request_is_409(self, request_service_mock):
+        request_service_mock.return_value.cancel.side_effect = ValueError("decided")
+
+        with self.assertRaises(HTTPException) as ctx:
+            await project_routes.cancel_access_request(
+                uuid4(),
+                uuid4(),
+                MagicMock(),
+                make_user(),
+            )
+
+        self.assertEqual(ctx.exception.status_code, 409)
+
+
+class OwnerDecisionRouteTests(IsolatedAsyncioTestCase):
+    def _patch_owner_project(self, project):
+        """_load_project_and_membership is the shared owner gate; stub it so
+        these tests cover the decision logic, not authz (see test_authz.py)."""
+
+        return patch.object(
+            project_routes,
+            "_load_project_and_membership",
+            return_value=(
+                MagicMock(),
+                project,
+                SimpleNamespace(role=ProjectRole.OWNER),
+            ),
+        )
+
+    @patch.object(project_routes.settings, "auth_mode", AuthMode.OIDC)
+    @patch("app.api.routes.projects.AccessRequestService")
+    async def test_lists_pending_requests_by_default(self, request_service_mock):
+        project = make_project()
+        user = make_user()
+        request_service_mock.return_value.list_for_project.return_value = [
+            stored_request(user),
+        ]
+
+        with self._patch_owner_project(project):
+            result = await project_routes.list_access_requests(
+                project.id,
+                "pending",
+                MagicMock(),
+                user,
+            )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].email, "me@corp")
+        request_service_mock.return_value.list_for_project.assert_called_once_with(
+            project,
+            AccessRequestStatus.PENDING,
+        )
+
+    @patch.object(project_routes.settings, "auth_mode", AuthMode.OIDC)
+    @patch("app.api.routes.projects.AccessRequestService")
+    async def test_status_all_passes_none(self, request_service_mock):
+        project = make_project()
+        request_service_mock.return_value.list_for_project.return_value = []
+
+        with self._patch_owner_project(project):
+            await project_routes.list_access_requests(
+                project.id,
+                "all",
+                MagicMock(),
+                make_user(),
+            )
+
+        request_service_mock.return_value.list_for_project.assert_called_once_with(
+            project,
+            None,
+        )
+
+    @patch.object(project_routes.settings, "auth_mode", AuthMode.OIDC)
+    @patch("app.api.routes.projects.AccessRequestService")
+    async def test_approve_forwards_the_selected_role(self, request_service_mock):
+        project = make_project()
+        user = make_user()
+        decided = stored_request(user, AccessRequestStatus.APPROVED)
+        request_service_mock.return_value.approve.return_value = decided
+
+        with self._patch_owner_project(project):
+            result = await project_routes.approve_access_request(
+                project.id,
+                decided.id,
+                AccessRequestDecision(role=ProjectRole.EDITOR),
+                MagicMock(),
+                user,
+            )
+
+        self.assertEqual(result.status, AccessRequestStatus.APPROVED)
+        request_service_mock.return_value.approve.assert_called_once_with(
+            project,
+            decided.id,
+            user,
+            ProjectRole.EDITOR,
+        )
+
+    @patch.object(project_routes.settings, "auth_mode", AuthMode.OIDC)
+    @patch("app.api.routes.projects.AccessRequestService")
+    async def test_approve_defaults_to_viewer(self, request_service_mock):
+        project = make_project()
+        user = make_user()
+        decided = stored_request(user, AccessRequestStatus.APPROVED)
+        request_service_mock.return_value.approve.return_value = decided
+
+        with self._patch_owner_project(project):
+            await project_routes.approve_access_request(
+                project.id,
+                decided.id,
+                AccessRequestDecision(),
+                MagicMock(),
+                user,
+            )
+
+        self.assertEqual(
+            request_service_mock.return_value.approve.call_args.args[3],
+            ProjectRole.VIEWER,
+        )
+
+    @patch.object(project_routes.settings, "auth_mode", AuthMode.OIDC)
+    @patch("app.api.routes.projects.AccessRequestService")
+    async def test_deny_marks_the_request(self, request_service_mock):
+        project = make_project()
+        user = make_user()
+        decided = stored_request(user, AccessRequestStatus.DENIED)
+        request_service_mock.return_value.deny.return_value = decided
+
+        with self._patch_owner_project(project):
+            result = await project_routes.deny_access_request(
+                project.id,
+                decided.id,
+                MagicMock(),
+                user,
+            )
+
+        self.assertEqual(result.status, AccessRequestStatus.DENIED)
+
+    @patch.object(project_routes.settings, "auth_mode", AuthMode.OIDC)
+    @patch("app.api.routes.projects.AccessRequestService")
+    async def test_unknown_request_is_404(self, request_service_mock):
+        project = make_project()
+        request_service_mock.return_value.approve.side_effect = LookupError("gone")
+
+        with self._patch_owner_project(project):
+            with self.assertRaises(HTTPException) as ctx:
+                await project_routes.approve_access_request(
+                    project.id,
+                    uuid4(),
+                    AccessRequestDecision(),
+                    MagicMock(),
+                    make_user(),
+                )
+
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    @patch.object(project_routes.settings, "auth_mode", AuthMode.TOKEN)
+    @patch.object(project_routes.settings, "access_token", "secret")
+    async def test_listing_is_hidden_outside_oidc_mode(self):
+        with self.assertRaises(HTTPException) as ctx:
+            await project_routes.list_access_requests(
+                uuid4(),
+                "pending",
+                MagicMock(),
+                make_user(),
+            )
+
+        self.assertEqual(ctx.exception.status_code, 404)

--- a/docs/api.md
+++ b/docs/api.md
@@ -216,6 +216,121 @@ Partial update — include only the fields to change. All fields are optional.
 
 ---
 
+## Project Access Requests
+
+A project is reachable at the permalink `/projects/{project_id}`. Anyone signed
+in may look it up; joining it requires an owner's approval. These endpoints
+exist only when `AUTH_MODE=oidc` — in `none` and `token` mode they return `404`,
+because those modes share a single local user. `/preview` is the exception and
+works in every mode.
+
+### Preview a project
+`GET /api/projects/{project_id}/preview`
+
+Permalink landing data. Unlike `GET /api/projects/{project_id}`, this does not
+return `404` for non-members: it deliberately reveals the name and owners to
+whoever holds the project UUID.
+
+**Response:**
+```json
+{
+  "id": "8f3c1d2e-4b5a-4c6d-9e8f-0a1b2c3d4e5f",
+  "name": "Q3 Customer Calls",
+  "owners": [{ "display_name": "Ada Lovelace", "email": "ada@example.com" }],
+  "my_role": null,
+  "request_status": null,
+  "request_id": null,
+  "can_request": true
+}
+```
+
+`404` only when no project with that id exists.
+
+---
+
+### Request access
+`POST /api/projects/{project_id}/access-requests`
+
+Ask the project's owners for membership. A previously denied request is reopened
+rather than duplicated, so one user never produces more than one row.
+
+**Request:**
+```json
+{ "message": "I'm joining the QBR team" }
+```
+
+`message` is optional and capped at 500 characters.
+
+**Response:** Access request object with `status: pending`. Returns `409` when
+the caller is already a member.
+
+---
+
+### Cancel your request
+`DELETE /api/projects/{project_id}/access-requests/{request_id}`
+
+Withdraw your own pending request. `404` if the request is not yours, `409` if
+an owner has already decided it.
+
+**Response:**
+```json
+{ "message": "Access request cancelled" }
+```
+
+---
+
+### List access requests
+`GET /api/projects/{project_id}/access-requests?status=pending`
+
+Owner only. `status` accepts `pending` (default), `approved`, `denied`, or `all`.
+
+**Response:**
+```json
+[
+  {
+    "id": "1f0e...",
+    "project_id": "8f3c...",
+    "user_id": "b21d...",
+    "email": "bob@example.com",
+    "display_name": "Bob Miller",
+    "status": "pending",
+    "message": "I'm joining the QBR team",
+    "created_at": "2026-08-20T10:00:00",
+    "decided_at": null,
+    "decided_by_name": null
+  }
+]
+```
+
+---
+
+### Approve a request
+`POST /api/projects/{project_id}/access-requests/{request_id}/approve`
+
+Owner only. Creates the membership with the chosen role and marks the request
+approved. Calling it again on an approved request is a no-op.
+
+**Request:**
+```json
+{ "role": "viewer" }
+```
+
+`role` defaults to `viewer`, the lowest role.
+
+**Response:** Access request object with `status: approved`.
+
+---
+
+### Deny a request
+`POST /api/projects/{project_id}/access-requests/{request_id}/deny`
+
+Owner only. Keeps the row with `status: denied` plus the decider and timestamp.
+The requester may ask again later.
+
+**Response:** Access request object with `status: denied`.
+
+---
+
 ## System
 
 ### Health check

--- a/docs/oidc-setup.md
+++ b/docs/oidc-setup.md
@@ -237,6 +237,32 @@ inherit them:
 - If `INITIAL_OWNER_EMAIL` is left empty, pre-existing entries stay invisible until
   you set it (the API logs a warning on startup).
 
+## Project permalinks and access requests
+
+Every project has a permanent URL at `/projects/{project_id}`; the copy-link
+button on the sidebar row — and in **Project Settings** — puts it on the
+clipboard.
+
+Anyone signed in who opens that URL sees the project name and its owners, even
+without membership. A project UUID is unguessable, and that disclosure is the
+point of a shareable link; description, member count, and entries stay hidden.
+A non-member can send an access request with an optional note.
+
+Owners review requests in **Project Settings → Access requests**, with a count
+badge on the project in the sidebar, and approve each one with a role (Viewer by
+default) or deny it. Approving is the only path from a request to membership,
+and the role is always the owner's choice.
+
+A denied user may request again. The request reuses the same row, so an owner's
+list never fills up with repeats from one person.
+
+Requests are an OIDC-mode feature. In `none` and `token` mode every request
+endpoint returns 404, because those modes share a single local user for whom
+requesting access would be meaningless. Permalinks themselves work in all modes.
+
+Someone who opens a permalink while signed out is sent through the IdP and
+returns to the project page afterwards, not to the dashboard.
+
 ## Troubleshooting
 
 If the callback fails, VoiceVault redirects to `/?auth_error=<code>` rather than

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,11 +10,13 @@ import { MoveToProjectModal } from './components/MoveToProjectModal';
 import { Login } from './components/Login';
 import { PromptTemplateManager } from './components/PromptTemplateManager';
 import { SearchBar } from './components/SearchBar';
-import { Sidebar, EntryView } from './components/Sidebar';
+import { Sidebar } from './components/Sidebar';
 import { CreateProjectModal } from './components/CreateProjectModal';
 import { ProjectSettingsModal } from './components/ProjectSettingsModal';
+import { ProjectAccessRequest } from './components/ProjectAccessRequest';
 import { entryApi, projectApi } from './services/api';
 import { useAuth } from './context/AuthContext';
+import { useRoute } from './hooks/useRoute';
 import {
   Entry,
   Project,
@@ -46,8 +48,10 @@ function App() {
   const [movingEntry, setMovingEntry] = useState<Entry | null>(null);
   const [entryFilter, setEntryFilter] = useState<EntryFilter>('active');
   const isArchivedView = entryFilter === 'archived';
-  const [view, setView] = useState<EntryView>({ kind: 'all' });
+  const { route: view, navigate } = useRoute();
   const [projects, setProjects] = useState<Project[]>([]);
+  // Distinguishes "not a member" from "the project list has not arrived yet".
+  const [projectsLoaded, setProjectsLoaded] = useState(false);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isCreateProjectOpen, setIsCreateProjectOpen] = useState(false);
   const [settingsProject, setSettingsProject] = useState<Project | null>(null);
@@ -95,6 +99,8 @@ function App() {
       setProjects(await projectApi.list());
     } catch (e) {
       console.error('Failed to fetch projects:', e);
+    } finally {
+      setProjectsLoaded(true);
     }
   }, []);
 
@@ -173,6 +179,9 @@ function App() {
     setIsAddEntryOpen(false);
     setIsTemplateManagerOpen(false);
     setEntryFilter('active');
+    // Do not leave the next user standing on a project they cannot see.
+    navigate({ kind: 'all' });
+    setProjectsLoaded(false);
   };
 
   const handleDeleteEntry = async (entry: Entry) => {
@@ -288,6 +297,16 @@ function App() {
 
   const hasMore = entries.length < total;
 
+  const isForeignProject =
+    view.kind === 'project' &&
+    projectsLoaded &&
+    !projects.some((project) => project.id === view.projectId);
+
+  const handleAccessGranted = useCallback(() => {
+    fetchProjects();
+    fetchEntries(1, false);
+  }, [fetchProjects, fetchEntries]);
+
   if (authLoading) {
     return <div className="min-h-screen" />;
   }
@@ -357,7 +376,7 @@ function App() {
             view={view}
             projects={projects}
             onSelectView={(nextView) => {
-              setView(nextView);
+              navigate(nextView);
               setPage(1);
               setIsSidebarOpen(false);
             }}
@@ -366,65 +385,76 @@ function App() {
           />
         </aside>
         <main className="flex-1 px-4 sm:px-6 lg:px-8 py-8">
-          <div className="space-y-8">
-            <div className="flex flex-col gap-3 md:flex-row md:items-center">
-              <div className="flex-1">
-                <SearchBar value={searchQuery} onChange={handleSearchChange} />
-              </div>
-              <div className="inline-flex rounded-lg border border-gray-200 bg-white p-1">
+          {isForeignProject && view.kind === 'project' ? (
+            <ProjectAccessRequest
+              projectId={view.projectId}
+              onAccessGranted={handleAccessGranted}
+            />
+          ) : (
+            <div className="space-y-8">
+              <div className="flex flex-col gap-3 md:flex-row md:items-center">
+                <div className="flex-1">
+                  <SearchBar value={searchQuery} onChange={handleSearchChange} />
+                </div>
+                <div className="inline-flex rounded-lg border border-gray-200 bg-white p-1">
+                  <button
+                    onClick={() => handleFilterChange('active')}
+                    className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                      !isArchivedView
+                        ? 'bg-gray-900 text-white'
+                        : 'text-gray-600 hover:text-gray-900'
+                    }`}
+                  >
+                    Active
+                  </button>
+                  <button
+                    onClick={() => handleFilterChange('archived')}
+                    className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                      isArchivedView
+                        ? 'bg-gray-900 text-white'
+                        : 'text-gray-600 hover:text-gray-900'
+                    }`}
+                  >
+                    Archived
+                  </button>
+                </div>
                 <button
-                  onClick={() => handleFilterChange('active')}
-                  className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                    !isArchivedView ? 'bg-gray-900 text-white' : 'text-gray-600 hover:text-gray-900'
-                  }`}
+                  onClick={() => setIsAddEntryOpen(true)}
+                  className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary-600 px-4 py-2 font-medium text-white transition-colors hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+                  aria-label="Add new entry"
                 >
-                  Active
-                </button>
-                <button
-                  onClick={() => handleFilterChange('archived')}
-                  className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                    isArchivedView ? 'bg-gray-900 text-white' : 'text-gray-600 hover:text-gray-900'
-                  }`}
-                >
-                  Archived
+                  <Plus className="h-4 w-4" />
+                  Add
                 </button>
               </div>
-              <button
-                onClick={() => setIsAddEntryOpen(true)}
-                className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary-600 px-4 py-2 font-medium text-white transition-colors hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
-                aria-label="Add new entry"
-              >
-                <Plus className="h-4 w-4" />
-                Add
-              </button>
-            </div>
 
-            {loading ? (
-              <div className="text-center py-12">
-                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mx-auto"></div>
-                <p className="mt-2 text-gray-500">Loading entries...</p>
-              </div>
-            ) : (
-              <EntryList
-                entries={entries}
-                total={total}
-                hasMore={hasMore}
-                isLoadingMore={isLoadingMore}
-                isArchivedView={isArchivedView}
-                projects={projects}
-                currentUserId={user?.id}
-                onRefresh={handleRefresh}
-                onOpenChat={handleOpenChat}
-                onDelete={handleDeleteEntry}
-                onToggleArchive={handleToggleArchive}
-                onEditMetadata={handleEditMetadata}
-                onViewTimestamps={handleViewTimestamps}
-                onMoveEntry={setMovingEntry}
-                onLoadMore={handleLoadMore}
-                isSearching={!!searchQuery}
-              />
-            )}
-          </div>
+              {loading ? (
+                <div className="text-center py-12">
+                  <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mx-auto"></div>
+                  <p className="mt-2 text-gray-500">Loading entries...</p>
+                </div>
+              ) : (
+                <EntryList
+                  entries={entries}
+                  total={total}
+                  hasMore={hasMore}
+                  isLoadingMore={isLoadingMore}
+                  isArchivedView={isArchivedView}
+                  projects={projects}
+                  currentUserId={user?.id}
+                  onRefresh={handleRefresh}
+                  onOpenChat={handleOpenChat}
+                  onDelete={handleDeleteEntry}
+                  onToggleArchive={handleToggleArchive}
+                  onEditMetadata={handleEditMetadata}
+                  onViewTimestamps={handleViewTimestamps}
+                  onMoveEntry={setMovingEntry}
+                  onLoadMore={handleLoadMore}
+                  isSearching={!!searchQuery}
+                />
+              )}
+            </div>
+          )}
         </main>
       </div>
 

--- a/ui/src/components/AccessRequestList.test.tsx
+++ b/ui/src/components/AccessRequestList.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { AccessRequestList } from './AccessRequestList';
+import { projectApi } from '../services/api';
+import { AccessRequest } from '../types';
+
+vi.mock('../services/api', () => ({
+  projectApi: {
+    listAccessRequests: vi.fn(),
+    approveRequest: vi.fn(),
+    denyRequest: vi.fn(),
+  },
+}));
+
+const pendingRequest: AccessRequest = {
+  id: 'r1',
+  project_id: 'p1',
+  user_id: 'u2',
+  email: 'bob@corp',
+  display_name: 'Bob',
+  status: 'pending',
+  message: 'joining the QBR team',
+  created_at: '2026-08-20T10:00:00Z',
+  decided_at: null,
+  decided_by_name: null,
+};
+
+const mocked = vi.mocked(projectApi);
+
+describe('AccessRequestList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocked.listAccessRequests.mockResolvedValue([pendingRequest]);
+  });
+
+  it('lists pending requesters with their note', async () => {
+    render(<AccessRequestList projectId="p1" onChanged={vi.fn()} />);
+
+    expect(await screen.findByText('Bob')).toBeInTheDocument();
+    expect(screen.getByText('bob@corp')).toBeInTheDocument();
+    expect(screen.getByText('joining the QBR team')).toBeInTheDocument();
+  });
+
+  it('defaults the role select to viewer', async () => {
+    render(<AccessRequestList projectId="p1" onChanged={vi.fn()} />);
+
+    const select = (await screen.findByLabelText('Role for Bob')) as HTMLSelectElement;
+    expect(select.value).toBe('viewer');
+  });
+
+  it('approves with the selected role and notifies the parent', async () => {
+    const onChanged = vi.fn();
+    mocked.approveRequest.mockResolvedValue({ ...pendingRequest, status: 'approved' });
+    render(<AccessRequestList projectId="p1" onChanged={onChanged} />);
+
+    fireEvent.change(await screen.findByLabelText('Role for Bob'), {
+      target: { value: 'editor' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Approve Bob' }));
+
+    await waitFor(() => expect(mocked.approveRequest).toHaveBeenCalledWith('p1', 'r1', 'editor'));
+    expect(onChanged).toHaveBeenCalled();
+  });
+
+  it('denies a request', async () => {
+    mocked.denyRequest.mockResolvedValue({ ...pendingRequest, status: 'denied' });
+    render(<AccessRequestList projectId="p1" onChanged={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Deny Bob' }));
+
+    await waitFor(() => expect(mocked.denyRequest).toHaveBeenCalledWith('p1', 'r1'));
+  });
+
+  it('says so when nothing is pending', async () => {
+    mocked.listAccessRequests.mockResolvedValue([]);
+    render(<AccessRequestList projectId="p1" onChanged={vi.fn()} />);
+
+    expect(await screen.findByText('No pending requests.')).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/AccessRequestList.tsx
+++ b/ui/src/components/AccessRequestList.tsx
@@ -1,0 +1,116 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import axios from 'axios';
+import { Check, X } from 'lucide-react';
+
+import { projectApi } from '../services/api';
+import { AccessRequest, ProjectRole } from '../types';
+
+interface AccessRequestListProps {
+  projectId: string;
+  onChanged: () => void;
+}
+
+const ROLES: ProjectRole[] = ['viewer', 'editor', 'owner'];
+
+export const AccessRequestList: React.FC<AccessRequestListProps> = ({ projectId, onChanged }) => {
+  const [requests, setRequests] = useState<AccessRequest[]>([]);
+  const [roles, setRoles] = useState<Record<string, ProjectRole>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      setRequests(await projectApi.listAccessRequests(projectId, 'pending'));
+    } catch {
+      setError('Failed to load access requests.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const errorFrom = (err: unknown, fallback: string): string => {
+    const detail = axios.isAxiosError(err) ? err.response?.data?.detail : undefined;
+    return detail || fallback;
+  };
+
+  const decide = async (request: AccessRequest, approve: boolean) => {
+    setError(null);
+    try {
+      if (approve) {
+        await projectApi.approveRequest(projectId, request.id, roles[request.id] ?? 'viewer');
+      } else {
+        await projectApi.denyRequest(projectId, request.id);
+      }
+      setRequests((current) => current.filter((item) => item.id !== request.id));
+      onChanged();
+    } catch (err) {
+      setError(errorFrom(err, 'Failed to update the request.'));
+    }
+  };
+
+  if (isLoading) {
+    return <p className="text-sm text-gray-500">Loading…</p>;
+  }
+
+  return (
+    <div className="space-y-2">
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {requests.length === 0 && <p className="text-sm text-gray-500">No pending requests.</p>}
+
+      {requests.map((request) => (
+        <div key={request.id} className="space-y-2 rounded-lg border border-gray-200 px-3 py-2">
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium text-gray-900">{request.display_name}</p>
+            <p className="truncate text-xs text-gray-500">{request.email}</p>
+            {request.message && <p className="mt-1 text-xs text-gray-600">{request.message}</p>}
+          </div>
+          <div className="flex items-center gap-2">
+            <select
+              value={roles[request.id] ?? 'viewer'}
+              onChange={(event) =>
+                setRoles((current) => ({
+                  ...current,
+                  [request.id]: event.target.value as ProjectRole,
+                }))
+              }
+              aria-label={`Role for ${request.display_name}`}
+              className="rounded-md border border-gray-300 px-2 py-1 text-xs focus:border-primary-500 focus:outline-none"
+            >
+              {ROLES.map((role) => (
+                <option key={role} value={role}>
+                  {role}
+                </option>
+              ))}
+            </select>
+            <button
+              onClick={() => decide(request, true)}
+              aria-label={`Approve ${request.display_name}`}
+              className="inline-flex items-center gap-1 rounded-lg bg-primary-600 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-primary-700"
+            >
+              <Check className="h-3 w-3" />
+              Approve
+            </button>
+            <button
+              onClick={() => decide(request, false)}
+              aria-label={`Deny ${request.display_name}`}
+              className="inline-flex items-center gap-1 rounded-lg px-3 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-100"
+            >
+              <X className="h-3 w-3" />
+              Deny
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/ui/src/components/Login.test.tsx
+++ b/ui/src/components/Login.test.tsx
@@ -36,4 +36,28 @@ describe('Login', () => {
 
     await waitFor(() => expect(loginWithToken).toHaveBeenCalledWith('secret-token'));
   });
+
+  it('sends the current path along to the OIDC login', () => {
+    window.history.replaceState({}, '', '/projects/8f3c1d2e-4b5a-4c6d-9e8f-0a1b2c3d4e5f');
+    mockUseAuth.mockReturnValue({ mode: 'oidc', loginWithToken: vi.fn() });
+
+    render(<Login />);
+
+    expect(screen.getByText('Sign in with SSO').closest('a')).toHaveAttribute(
+      'href',
+      '/api/auth/oidc/login?next=%2Fprojects%2F8f3c1d2e-4b5a-4c6d-9e8f-0a1b2c3d4e5f',
+    );
+  });
+
+  it('omits next on the root path', () => {
+    window.history.replaceState({}, '', '/');
+    mockUseAuth.mockReturnValue({ mode: 'oidc', loginWithToken: vi.fn() });
+
+    render(<Login />);
+
+    expect(screen.getByText('Sign in with SSO').closest('a')).toHaveAttribute(
+      'href',
+      '/api/auth/oidc/login',
+    );
+  });
 });

--- a/ui/src/components/Login.tsx
+++ b/ui/src/components/Login.tsx
@@ -31,6 +31,16 @@ const Shell: React.FC<{ subtitle: string; children: React.ReactNode }> = ({
   </div>
 );
 
+// Only the path travels — the query string can still hold auth_error from a
+// previous failed attempt, and echoing that back is noise.
+const oidcLoginHref = (): string => {
+  const path = window.location.pathname;
+  if (path === '/') {
+    return '/api/auth/oidc/login';
+  }
+  return `/api/auth/oidc/login?next=${encodeURIComponent(path)}`;
+};
+
 export const Login: React.FC = () => {
   const { mode, loginWithToken } = useAuth();
   const [token, setToken] = useState('');
@@ -86,7 +96,7 @@ export const Login: React.FC = () => {
             </div>
           )}
           <a
-            href="/api/auth/oidc/login"
+            href={oidcLoginHref()}
             className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
           >
             Sign in with SSO

--- a/ui/src/components/ProjectAccessRequest.test.tsx
+++ b/ui/src/components/ProjectAccessRequest.test.tsx
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ProjectAccessRequest } from './ProjectAccessRequest';
+import { projectApi } from '../services/api';
+import { ProjectPreview } from '../types';
+
+vi.mock('../services/api', () => ({
+  projectApi: {
+    preview: vi.fn(),
+    requestAccess: vi.fn(),
+    cancelRequest: vi.fn(),
+  },
+}));
+
+const basePreview: ProjectPreview = {
+  id: 'p1',
+  name: 'Team Alpha',
+  owners: [{ display_name: 'Ada', email: 'ada@corp' }],
+  my_role: null,
+  request_status: null,
+  request_id: null,
+  can_request: true,
+};
+
+const mocked = vi.mocked(projectApi);
+
+describe('ProjectAccessRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the project name, owners and a request button', async () => {
+    mocked.preview.mockResolvedValue(basePreview);
+    render(<ProjectAccessRequest projectId="p1" onAccessGranted={vi.fn()} />);
+
+    expect(await screen.findByText('Team Alpha')).toBeInTheDocument();
+    expect(screen.getByText(/ada@corp/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Request access' })).toBeInTheDocument();
+  });
+
+  it('sends the note with the request and switches to pending', async () => {
+    mocked.preview.mockResolvedValue(basePreview);
+    mocked.requestAccess.mockResolvedValue({
+      id: 'r1',
+      project_id: 'p1',
+      user_id: 'u1',
+      email: 'me@corp',
+      display_name: 'Me',
+      status: 'pending',
+      message: 'joining the QBR team',
+      created_at: '2026-08-20T10:00:00Z',
+      decided_at: null,
+      decided_by_name: null,
+    });
+
+    render(<ProjectAccessRequest projectId="p1" onAccessGranted={vi.fn()} />);
+    fireEvent.change(await screen.findByPlaceholderText(/why do you need access/i), {
+      target: { value: 'joining the QBR team' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Request access' }));
+
+    await waitFor(() =>
+      expect(mocked.requestAccess).toHaveBeenCalledWith('p1', 'joining the QBR team'),
+    );
+    expect(await screen.findByText(/waiting for an owner/i)).toBeInTheDocument();
+  });
+
+  it('offers to cancel a pending request', async () => {
+    mocked.preview.mockResolvedValue({
+      ...basePreview,
+      request_status: 'pending',
+      request_id: 'r1',
+    });
+    mocked.cancelRequest.mockResolvedValue(undefined);
+
+    render(<ProjectAccessRequest projectId="p1" onAccessGranted={vi.fn()} />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel request' }));
+
+    await waitFor(() => expect(mocked.cancelRequest).toHaveBeenCalledWith('p1', 'r1'));
+    expect(await screen.findByRole('button', { name: 'Request access' })).toBeInTheDocument();
+  });
+
+  it('lets a denied user try again', async () => {
+    mocked.preview.mockResolvedValue({
+      ...basePreview,
+      request_status: 'denied',
+      request_id: 'r1',
+    });
+
+    render(<ProjectAccessRequest projectId="p1" onAccessGranted={vi.fn()} />);
+
+    expect(await screen.findByText(/was declined/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Request again' })).toBeInTheDocument();
+  });
+
+  it('notifies the parent once access has been granted', async () => {
+    const onAccessGranted = vi.fn();
+    mocked.preview.mockResolvedValue({
+      ...basePreview,
+      my_role: 'viewer',
+      request_status: 'approved',
+      request_id: 'r1',
+      can_request: false,
+    });
+
+    render(<ProjectAccessRequest projectId="p1" onAccessGranted={onAccessGranted} />);
+
+    await waitFor(() => expect(onAccessGranted).toHaveBeenCalled());
+  });
+
+  it('hides the request control when the deployment does not support it', async () => {
+    mocked.preview.mockResolvedValue({ ...basePreview, can_request: false });
+
+    render(<ProjectAccessRequest projectId="p1" onAccessGranted={vi.fn()} />);
+
+    expect(await screen.findByText('Team Alpha')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Request access' })).not.toBeInTheDocument();
+  });
+
+  it('explains a missing project', async () => {
+    mocked.preview.mockRejectedValue(new Error('404'));
+
+    render(<ProjectAccessRequest projectId="p1" onAccessGranted={vi.fn()} />);
+
+    expect(await screen.findByText(/no longer available/i)).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/ProjectAccessRequest.tsx
+++ b/ui/src/components/ProjectAccessRequest.tsx
@@ -1,0 +1,167 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import axios from 'axios';
+import { FolderLock, Loader2 } from 'lucide-react';
+
+import { projectApi } from '../services/api';
+import { ProjectPreview } from '../types';
+
+interface ProjectAccessRequestProps {
+  projectId: string;
+  onAccessGranted: () => void;
+}
+
+export const ProjectAccessRequest: React.FC<ProjectAccessRequestProps> = ({
+  projectId,
+  onAccessGranted,
+}) => {
+  const [preview, setPreview] = useState<ProjectPreview | null>(null);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      setPreview(await projectApi.preview(projectId));
+    } catch {
+      setPreview(null);
+      setError('This project does not exist or is no longer available.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // An approval that landed while this page was open: hand back to the app so
+  // it can refetch projects and render the real project view.
+  useEffect(() => {
+    if (preview?.my_role) {
+      onAccessGranted();
+    }
+  }, [preview, onAccessGranted]);
+
+  const errorFrom = (err: unknown, fallback: string): string => {
+    const detail = axios.isAxiosError(err) ? err.response?.data?.detail : undefined;
+    return detail || fallback;
+  };
+
+  const handleRequest = async () => {
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const request = await projectApi.requestAccess(projectId, message.trim() || undefined);
+      setPreview((current) =>
+        current ? { ...current, request_status: request.status, request_id: request.id } : current,
+      );
+      setMessage('');
+    } catch (err) {
+      setError(errorFrom(err, 'Could not send the request. Please try again.'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    if (!preview?.request_id) {
+      return;
+    }
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await projectApi.cancelRequest(projectId, preview.request_id);
+      setPreview({ ...preview, request_status: null, request_id: null });
+    } catch (err) {
+      setError(errorFrom(err, 'Could not cancel the request.'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-16 text-gray-500">
+        <Loader2 className="h-5 w-5 animate-spin" />
+      </div>
+    );
+  }
+
+  if (!preview) {
+    return (
+      <div className="mx-auto max-w-md rounded-2xl border border-gray-200 bg-white p-6 text-center">
+        <p className="text-sm text-gray-600">{error}</p>
+      </div>
+    );
+  }
+
+  const status = preview.request_status;
+  const showRequestButton = preview.can_request && status !== 'pending';
+
+  return (
+    <div className="mx-auto max-w-md space-y-4 rounded-2xl border border-gray-200 bg-white p-6">
+      <div className="flex items-center gap-3">
+        <div className="rounded-full bg-gray-100 p-2 text-gray-700">
+          <FolderLock className="h-5 w-5" />
+        </div>
+        <div className="min-w-0">
+          <h2 className="truncate text-lg font-semibold text-gray-900">{preview.name}</h2>
+          <p className="text-sm text-gray-500">You do not have access to this project.</p>
+        </div>
+      </div>
+
+      {preview.owners.length > 0 && (
+        <p className="text-sm text-gray-600">
+          Owners:{' '}
+          {preview.owners.map((owner) => `${owner.display_name} (${owner.email})`).join(', ')}
+        </p>
+      )}
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {status === 'pending' && (
+        <div className="space-y-2">
+          <p className="text-sm text-gray-700">Request sent — waiting for an owner to review it.</p>
+          <button
+            onClick={handleCancel}
+            disabled={isSubmitting}
+            className="rounded-lg px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 disabled:opacity-50"
+          >
+            Cancel request
+          </button>
+        </div>
+      )}
+
+      {status === 'denied' && (
+        <p className="text-sm text-gray-700">Your previous request was declined.</p>
+      )}
+
+      {showRequestButton && (
+        <div className="space-y-2">
+          <textarea
+            value={message}
+            onChange={(event) => setMessage(event.target.value)}
+            rows={2}
+            maxLength={500}
+            placeholder="Why do you need access? (optional)"
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-primary-500"
+          />
+          <button
+            onClick={handleRequest}
+            disabled={isSubmitting}
+            className="rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {status === 'denied' ? 'Request again' : 'Request access'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/ui/src/components/ProjectSettingsModal.tsx
+++ b/ui/src/components/ProjectSettingsModal.tsx
@@ -1,9 +1,11 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import axios from 'axios';
-import { LogOut, Settings, Trash2, UserPlus, X } from 'lucide-react';
+import { Link, LogOut, Settings, Trash2, UserPlus, X } from 'lucide-react';
 
 import { projectApi } from '../services/api';
 import { useAuth } from '../context/AuthContext';
+import { AccessRequestList } from './AccessRequestList';
+import { permalinkFor } from '../hooks/useRoute';
 import { Project, ProjectDetail, ProjectRole } from '../types';
 
 interface ProjectSettingsModalProps {
@@ -23,7 +25,7 @@ export const ProjectSettingsModal: React.FC<ProjectSettingsModalProps> = ({
   onChanged,
   onDeletedOrLeft,
 }) => {
-  const { user } = useAuth();
+  const { user, mode } = useAuth();
   const [detail, setDetail] = useState<ProjectDetail | null>(null);
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -163,6 +165,14 @@ export const ProjectSettingsModal: React.FC<ProjectSettingsModalProps> = ({
             </div>
           </div>
           <button
+            onClick={() => void navigator.clipboard?.writeText(permalinkFor(project.id))}
+            className="ml-auto mr-1 rounded-md p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+            aria-label="Copy project link"
+            title="Copy project link"
+          >
+            <Link className="h-5 w-5" />
+          </button>
+          <button
             onClick={onClose}
             className="rounded-md p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
             aria-label="Close"
@@ -291,6 +301,13 @@ export const ProjectSettingsModal: React.FC<ProjectSettingsModalProps> = ({
                   </form>
                 )}
               </section>
+
+              {isOwner && mode === 'oidc' && (
+                <section className="space-y-3">
+                  <h3 className="text-sm font-semibold text-gray-900">Access requests</h3>
+                  <AccessRequestList projectId={project.id} onChanged={refresh} />
+                </section>
+              )}
 
               <section className="flex flex-wrap items-center justify-between gap-2 border-t border-gray-100 pt-4">
                 {!isLastOwner && (

--- a/ui/src/components/Sidebar.test.tsx
+++ b/ui/src/components/Sidebar.test.tsx
@@ -46,4 +46,48 @@ describe('Sidebar', () => {
     fireEvent.click(screen.getByText('Team Alpha'));
     expect(onSelectView).toHaveBeenCalledWith({ kind: 'project', projectId: 'p1' });
   });
+
+  it('shows a pending request badge for owned projects', () => {
+    render(
+      <Sidebar
+        view={{ kind: 'all' }}
+        projects={[{ ...project, pending_request_count: 3 }]}
+        onSelectView={vi.fn()}
+        onCreateProject={vi.fn()}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText('3 pending access requests')).toHaveTextContent('3');
+  });
+
+  it('hides the badge when there is nothing pending', () => {
+    render(
+      <Sidebar
+        view={{ kind: 'all' }}
+        projects={[{ ...project, pending_request_count: 0 }]}
+        onSelectView={vi.fn()}
+        onCreateProject={vi.fn()}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+    expect(screen.queryByLabelText(/pending access requests/)).not.toBeInTheDocument();
+  });
+
+  it('copies the project permalink to the clipboard', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(
+      <Sidebar
+        view={{ kind: 'all' }}
+        projects={[project]}
+        onSelectView={vi.fn()}
+        onCreateProject={vi.fn()}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('Copy link to Team Alpha'));
+
+    expect(writeText).toHaveBeenCalledWith(`${window.location.origin}/projects/p1`);
+  });
 });

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { FileText, User as UserIcon, Plus, Settings, FolderOpen } from 'lucide-react';
+import { FileText, User as UserIcon, Plus, Settings, FolderOpen, Link } from 'lucide-react';
 import { Project } from '../types';
+import { Route, permalinkFor } from '../hooks/useRoute';
 
-export type EntryView = { kind: 'all' } | { kind: 'mine' } | { kind: 'project'; projectId: string };
+// The sidebar's selection and the URL are the same thing.
+export type EntryView = Route;
 
 interface SidebarProps {
   view: EntryView;
@@ -48,6 +50,10 @@ export const Sidebar: React.FC<SidebarProps> = ({
       </div>
       {projects.map((project) => {
         const active = view.kind === 'project' && view.projectId === project.id;
+        const pending = project.pending_request_count ?? 0;
+        const copyLink = () => {
+          void navigator.clipboard?.writeText(permalinkFor(project.id));
+        };
         return (
           <div key={project.id} className="group flex items-center">
             <button
@@ -60,6 +66,22 @@ export const Sidebar: React.FC<SidebarProps> = ({
               <span className="ml-auto rounded bg-gray-100 px-1.5 py-0.5 text-[10px] uppercase text-gray-500">
                 {project.my_role}
               </span>
+              {pending > 0 && (
+                <span
+                  className="ml-1 rounded-full bg-primary-600 px-1.5 py-0.5 text-[10px] font-semibold text-white"
+                  aria-label={`${pending} pending access requests`}
+                  title={`${pending} pending access requests`}
+                >
+                  {pending}
+                </span>
+              )}
+            </button>
+            <button
+              onClick={copyLink}
+              className="ml-1 hidden rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700 group-hover:block"
+              aria-label={`Copy link to ${project.name}`}
+            >
+              <Link className="h-4 w-4" />
             </button>
             <button
               onClick={() => onOpenSettings(project)}

--- a/ui/src/hooks/useRoute.test.ts
+++ b/ui/src/hooks/useRoute.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { parsePath, pathForRoute, useRoute } from './useRoute';
+
+const UUID = '8f3c1d2e-4b5a-4c6d-9e8f-0a1b2c3d4e5f';
+
+describe('parsePath', () => {
+  it('maps the root to the all-entries view', () => {
+    expect(parsePath('/')).toEqual({ kind: 'all' });
+  });
+
+  it('maps /mine to the personal view', () => {
+    expect(parsePath('/mine')).toEqual({ kind: 'mine' });
+  });
+
+  it('maps a project permalink to the project view', () => {
+    expect(parsePath(`/projects/${UUID}`)).toEqual({ kind: 'project', projectId: UUID });
+  });
+
+  it('tolerates a trailing slash', () => {
+    expect(parsePath(`/projects/${UUID}/`)).toEqual({ kind: 'project', projectId: UUID });
+  });
+
+  it('falls back to the root for a non-uuid project id', () => {
+    expect(parsePath('/projects/not-a-uuid')).toEqual({ kind: 'all' });
+  });
+
+  it('falls back to the root for an unknown path', () => {
+    expect(parsePath('/whatever')).toEqual({ kind: 'all' });
+  });
+});
+
+describe('pathForRoute', () => {
+  it('round-trips every route kind', () => {
+    expect(pathForRoute({ kind: 'all' })).toBe('/');
+    expect(pathForRoute({ kind: 'mine' })).toBe('/mine');
+    expect(pathForRoute({ kind: 'project', projectId: UUID })).toBe(`/projects/${UUID}`);
+  });
+});
+
+describe('useRoute', () => {
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('starts from the current location', () => {
+    window.history.replaceState({}, '', `/projects/${UUID}`);
+    const { result } = renderHook(() => useRoute());
+    expect(result.current.route).toEqual({ kind: 'project', projectId: UUID });
+  });
+
+  it('navigate pushes the new path and updates the route', () => {
+    const { result } = renderHook(() => useRoute());
+    act(() => result.current.navigate({ kind: 'project', projectId: UUID }));
+    expect(window.location.pathname).toBe(`/projects/${UUID}`);
+    expect(result.current.route).toEqual({ kind: 'project', projectId: UUID });
+  });
+
+  it('reacts to browser back', () => {
+    const { result } = renderHook(() => useRoute());
+    act(() => result.current.navigate({ kind: 'mine' }));
+    act(() => {
+      window.history.replaceState({}, '', '/');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+    expect(result.current.route).toEqual({ kind: 'all' });
+  });
+});

--- a/ui/src/hooks/useRoute.ts
+++ b/ui/src/hooks/useRoute.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export type Route = { kind: 'all' } | { kind: 'mine' } | { kind: 'project'; projectId: string };
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const PROJECT_PATH = /^\/projects\/([^/]+)\/?$/;
+
+export const parsePath = (pathname: string): Route => {
+  if (pathname === '/mine') {
+    return { kind: 'mine' };
+  }
+
+  const match = PROJECT_PATH.exec(pathname);
+  if (match && UUID_PATTERN.test(match[1])) {
+    return { kind: 'project', projectId: match[1] };
+  }
+
+  // Anything unrecognised — including a malformed project id — goes home
+  // rather than firing an API call that is guaranteed to 404.
+  return { kind: 'all' };
+};
+
+export const pathForRoute = (route: Route): string => {
+  switch (route.kind) {
+    case 'mine':
+      return '/mine';
+    case 'project':
+      return `/projects/${route.projectId}`;
+    default:
+      return '/';
+  }
+};
+
+export const permalinkFor = (projectId: string): string =>
+  `${window.location.origin}${pathForRoute({ kind: 'project', projectId })}`;
+
+export const useRoute = () => {
+  const [route, setRoute] = useState<Route>(() => parsePath(window.location.pathname));
+
+  useEffect(() => {
+    const handlePopState = () => setRoute(parsePath(window.location.pathname));
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
+
+  const navigate = useCallback((next: Route) => {
+    const path = pathForRoute(next);
+    if (path !== window.location.pathname) {
+      window.history.pushState({}, '', path);
+    }
+    setRoute(next);
+  }, []);
+
+  return { route, navigate };
+};

--- a/ui/src/services/api.ts
+++ b/ui/src/services/api.ts
@@ -19,6 +19,9 @@ import {
   ProjectCreate,
   ProjectUpdate,
   ProjectRole,
+  ProjectPreview,
+  AccessRequest,
+  AccessRequestStatus,
 } from '../types';
 
 const api = axios.create({
@@ -223,6 +226,48 @@ export const projectApi = {
 
   get: async (id: string): Promise<ProjectDetail> => {
     const response = await api.get(`/projects/${id}`);
+    return response.data;
+  },
+
+  preview: async (id: string): Promise<ProjectPreview> => {
+    const response = await api.get(`/projects/${id}/preview`);
+    return response.data;
+  },
+
+  requestAccess: async (id: string, message?: string): Promise<AccessRequest> => {
+    const response = await api.post(`/projects/${id}/access-requests`, {
+      message: message || null,
+    });
+    return response.data;
+  },
+
+  cancelRequest: async (id: string, requestId: string): Promise<void> => {
+    await api.delete(`/projects/${id}/access-requests/${requestId}`);
+  },
+
+  listAccessRequests: async (
+    id: string,
+    status: AccessRequestStatus | 'all' = 'pending',
+  ): Promise<AccessRequest[]> => {
+    const response = await api.get(`/projects/${id}/access-requests`, {
+      params: { status },
+    });
+    return response.data;
+  },
+
+  approveRequest: async (
+    id: string,
+    requestId: string,
+    role: ProjectRole,
+  ): Promise<AccessRequest> => {
+    const response = await api.post(`/projects/${id}/access-requests/${requestId}/approve`, {
+      role,
+    });
+    return response.data;
+  },
+
+  denyRequest: async (id: string, requestId: string): Promise<AccessRequest> => {
+    const response = await api.post(`/projects/${id}/access-requests/${requestId}/deny`);
     return response.data;
   },
 

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -141,6 +141,7 @@ export interface Project {
   my_role: ProjectRole;
   member_count: number;
   entry_count: number;
+  pending_request_count?: number;
 }
 
 export interface ProjectMember {
@@ -162,6 +163,36 @@ export interface ProjectCreate {
 export interface ProjectUpdate {
   name?: string;
   description?: string | null;
+}
+
+export type AccessRequestStatus = 'pending' | 'approved' | 'denied';
+
+export interface ProjectOwner {
+  display_name: string;
+  email: string;
+}
+
+export interface ProjectPreview {
+  id: string;
+  name: string;
+  owners: ProjectOwner[];
+  my_role: ProjectRole | null;
+  request_status: AccessRequestStatus | null;
+  request_id: string | null;
+  can_request: boolean;
+}
+
+export interface AccessRequest {
+  id: string;
+  project_id: string;
+  user_id: string;
+  email: string;
+  display_name: string;
+  status: AccessRequestStatus;
+  message: string | null;
+  created_at: string;
+  decided_at: string | null;
+  decided_by_name: string | null;
 }
 
 export const roleAtLeast = (role: ProjectRole | undefined, min: ProjectRole): boolean => {


### PR DESCRIPTION
Projects now have a shareable permalink at `/projects/{id}`, with a copy-link button on the sidebar row and in Project Settings.

A signed-in user who opens a link to a project they're not in sees its name and its owners — nothing else — and can request access with an optional note. Owners review pending requests in Project Settings, with a count badge on the project in the sidebar, and approve each one with a chosen role (Viewer by default) or deny it. Approval is the only path from a request to membership, and the role is always the owner's choice.

A denied user can ask again; the request reuses the same row, so one person can never flood an owner's list. Requesters see the outcome when they revisit the link and can withdraw a request while it's still pending.

Requests are an OIDC-mode feature — the endpoints return 404 in `none` and `token` mode, where a single shared local user makes them meaningless. Permalinks work in every auth mode, and following one while signed out now returns you to the project after SSO instead of the dashboard.
